### PR TITLE
Add UIChainsStore pruning functionality and integrate with lifespan and routes

### DIFF
--- a/app/im/chain/ui_chains_store.py
+++ b/app/im/chain/ui_chains_store.py
@@ -1,11 +1,13 @@
 import os
 from datetime import datetime, timezone, timedelta
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Tuple
 
 from icalendar import Calendar, Event
 
+from app.config.config import get_config
 from app.config.environment import get_environment_config
 from app.logging import logger
+from app.time import unix_sleep_to_timedelta
 
 
 def _chain_name_to_filename(chain_name: str) -> str:
@@ -30,6 +32,43 @@ class UIChainsStore:
     def load_shifts(self, chain_name: str) -> List[Dict[str, Any]]:
         if not chain_name:
             return []
+        shifts = self._read_shifts_from_disk(chain_name)
+        logger.debug("Loaded ui chains", extra={"chain": chain_name, "count": len(shifts)})
+        return self.recalculate_priorities(shifts)
+
+    def prune_expired_shifts(self, chain_name: str, now: Optional[datetime] = None) -> int:
+        if not chain_name:
+            return 0
+        shifts = self._read_shifts_from_disk(chain_name)
+        if not shifts:
+            return 0
+        retained, expired = self._partition_by_retention(shifts, now)
+        if not expired:
+            return 0
+        self._write_shifts(chain_name, retained)
+        logger.info(
+            "Pruned expired ui chain shifts",
+            extra={"chain": chain_name, "removed": len(expired)},
+        )
+        return len(expired)
+
+    def prune_all(self, now: Optional[datetime] = None) -> int:
+        if not os.path.exists(self.ui_chains_dir):
+            return 0
+        removed = 0
+        for filename in os.listdir(self.ui_chains_dir):
+            if not filename.endswith(".ics"):
+                continue
+            removed += self.prune_expired_shifts(filename[:-4], now)
+        return removed
+
+    def filter_retained_shifts(
+        self, shifts: List[Dict[str, Any]], now: Optional[datetime] = None
+    ) -> List[Dict[str, Any]]:
+        retained, _ = self._partition_by_retention(shifts, now)
+        return retained
+
+    def _read_shifts_from_disk(self, chain_name: str) -> List[Dict[str, Any]]:
         path = self._calendar_path(chain_name)
         if not os.path.exists(path):
             return []
@@ -44,12 +83,89 @@ class UIChainsStore:
                     shift = self._ical_event_to_chain(component)
                     if shift:
                         shifts.append(shift)
-
-            logger.debug("Loaded ui chains", extra={"chain": chain_name, "count": len(shifts)})
-            return self.recalculate_priorities(shifts)
+            return shifts
         except Exception as e:
             logger.error("Failed to load ui chains", extra={"error": str(e), "chain": chain_name})
             return []
+
+    def _write_shifts(self, chain_name: str, shifts: List[Dict[str, Any]]) -> bool:
+        path = self._calendar_path(chain_name)
+        try:
+            cal = Calendar()
+            cal.add("prodid", "-//IMPulse//impulse.calendar//EN")
+            cal.add("version", "2.0")
+            cal.add("calscale", "GREGORIAN")
+            cal.add("method", "PUBLISH")
+
+            for shift in shifts:
+                event = self._chain_to_ical_event(shift)
+                if event:
+                    cal.add_component(event)
+
+            with open(path, "wb") as f:
+                f.write(cal.to_ical())
+
+            logger.debug("Saved ui chains", extra={"chain": chain_name, "count": len(shifts)})
+            return True
+        except Exception as e:
+            logger.error("Failed to save ui chains", extra={"error": str(e), "chain": chain_name})
+            return False
+
+    def _retention_cutoff(self, now: datetime) -> datetime:
+        config = get_config()
+        retention = unix_sleep_to_timedelta(config.incident.timeouts.get("closed"))
+        return now - retention
+
+    def _partition_by_retention(
+        self, shifts: List[Dict[str, Any]], now: Optional[datetime] = None
+    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        now = now or datetime.now(timezone.utc)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        cutoff = self._retention_cutoff(now)
+        retained = []
+        expired = []
+        for shift in shifts:
+            if self._is_shift_expired(shift, cutoff):
+                expired.append(shift)
+            else:
+                retained.append(shift)
+        return retained, expired
+
+    def _is_shift_expired(self, shift: Dict[str, Any], cutoff: datetime) -> bool:
+        start = self._parse_datetime(shift.get("start"))
+        if start is None:
+            return True
+        effective_end = self._shift_effective_end(shift)
+        if effective_end is None:
+            return False
+        return effective_end < cutoff
+
+    def _shift_effective_end(self, shift: Dict[str, Any]) -> Optional[datetime]:
+        start = self._parse_datetime(shift.get("start"))
+        if start is None:
+            return None
+
+        end = self._parse_datetime(shift.get("end")) or (start + timedelta(days=1))
+        repeat = shift.get("repeat")
+        if not repeat:
+            return end
+
+        repeat_end = self._parse_datetime(shift.get("repeatEnd")) if shift.get("repeatEnd") else None
+        if repeat_end is None:
+            return None
+
+        duration = end - start
+        occurrence_start = start
+        occurrence_end = end
+        last_end = occurrence_end
+        while occurrence_start <= repeat_end:
+            if occurrence_end > repeat_end:
+                break
+            last_end = occurrence_end
+            occurrence_start = self._next_occurrence_start(start, occurrence_start, repeat)
+            occurrence_end = occurrence_start + duration
+        return last_end
 
     def get_steps_for_now(self, chain_name: str, now: Optional[datetime] = None) -> List[Dict[str, Any]]:
         shifts = self.load_shifts(chain_name)
@@ -75,28 +191,9 @@ class UIChainsStore:
     def save_shifts(self, chain_name: str, shifts: List[Dict[str, Any]]) -> bool:
         if not chain_name:
             return False
+        shifts = self.filter_retained_shifts(shifts)
         shifts = self.recalculate_priorities(shifts)
-        path = self._calendar_path(chain_name)
-        try:
-            cal = Calendar()
-            cal.add("prodid", "-//IMPulse//impulse.calendar//EN")
-            cal.add("version", "2.0")
-            cal.add("calscale", "GREGORIAN")
-            cal.add("method", "PUBLISH")
-
-            for shift in shifts:
-                event = self._chain_to_ical_event(shift)
-                if event:
-                    cal.add_component(event)
-
-            with open(path, "wb") as f:
-                f.write(cal.to_ical())
-
-            logger.debug("Saved ui chains", extra={"chain": chain_name, "count": len(shifts)})
-            return True
-        except Exception as e:
-            logger.error("Failed to save ui chains", extra={"error": str(e), "chain": chain_name})
-            return False
+        return self._write_shifts(chain_name, shifts)
 
     def _chain_to_ical_event(self, chain: Dict[str, Any]) -> Optional[Event]:
         try:

--- a/app/lifespan.py
+++ b/app/lifespan.py
@@ -22,6 +22,7 @@ from app.queue.manager import AsyncQueueManager
 from app.queue.queue import AsyncQueue
 from app.route import generate_route
 from app.webhook import generate_webhooks
+from app.im.chain.ui_chains_store import ui_chains_store
 
 
 async def _initialize_primary_server(fastapi_app: FastAPI, file_lock: FileLock) -> bool:
@@ -86,6 +87,7 @@ async def create_main_objects(fastapi_app: FastAPI, reload=False):
         await user_scheduler.schedule_all_stored()
         queue_manager = AsyncQueueManager(queue, messenger, incidents, webhooks, route, inhibition_manager, maintenance_manager)
         await maintenance_manager.reconcile_all()
+        ui_chains_store.prune_all()
 
         fastapi_app.state.queue_manager = queue_manager
         fastapi_app.state.incidents = incidents

--- a/app/routes.py
+++ b/app/routes.py
@@ -425,6 +425,7 @@ def create_router(http_prefix: str, fastapi_app: FastAPI = None, auth_manager=No
                             }))
                         else:
                             chain_name = message.get("chain_name", "")
+                            ui_chains_store.prune_expired_shifts(chain_name)
                             shifts = ui_chains_store.load_shifts(chain_name)
                             await websocket.send_text(json.dumps({"event": "ui_chains_data", "data": shifts}))
                     elif event_type == "save_ui_chains":

--- a/tests/test_chain/test_ui_chains_store.py
+++ b/tests/test_chain/test_ui_chains_store.py
@@ -2,7 +2,25 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
+from app.config.validation import IncidentTimeouts
 from app.im.chain.ui_chains_store import UIChainsStore
+
+
+def _make_store(tmp_path: Path) -> UIChainsStore:
+    with patch("app.im.chain.ui_chains_store.get_environment_config") as mock_get_environment_config:
+        mock_get_environment_config.return_value.data_path = str(tmp_path)
+        return UIChainsStore()
+
+
+def _mock_closed_retention(closed: str = "7d"):
+    timeouts = IncidentTimeouts(closed=closed)
+    mock_config = patch("app.im.chain.ui_chains_store.get_config").start()
+    mock_config.return_value.incident.timeouts = timeouts
+    return mock_config
+
+
+def _write_shifts_unfiltered(store: UIChainsStore, chain_name: str, shifts: list) -> None:
+    store._write_shifts(chain_name, store.recalculate_priorities(shifts))
 
 
 def test_ui_chains_dir_uses_environment_data_path(tmp_path: Path):
@@ -73,3 +91,134 @@ def test_recalculate_priorities_single_over_daily_repeat(tmp_path: Path):
     by_id = {c["id"]: c["priority"] for c in out}
     assert by_id["mnne7fqvs5q3r6l2ci"] == 1
     assert by_id["mnnf5iz2sv9io9s30yh"] == 2
+
+
+def test_prune_expired_shifts_removes_old_one_off_shift(tmp_path: Path):
+    store = _make_store(tmp_path)
+    mock_config = _mock_closed_retention("7d")
+    now = datetime(2026, 6, 16, 12, 0, tzinfo=timezone.utc)
+
+    try:
+        old_shift = {
+            "id": "old",
+            "start": "2026-05-01T10:00:00Z",
+            "end": "2026-05-01T12:00:00Z",
+            "steps": [{"user": "alice"}],
+        }
+        recent_shift = {
+            "id": "recent",
+            "start": "2026-06-10T10:00:00Z",
+            "end": "2026-06-10T12:00:00Z",
+            "steps": [{"user": "bob"}],
+        }
+        _write_shifts_unfiltered(store, "primary", [old_shift, recent_shift])
+
+        removed = store.prune_expired_shifts("primary", now)
+        assert removed == 1
+
+        remaining = store.load_shifts("primary")
+        assert len(remaining) == 1
+        assert remaining[0]["id"] == "recent"
+    finally:
+        mock_config.stop()
+
+
+def test_prune_expired_shifts_keeps_repeating_shift_without_repeat_end(tmp_path: Path):
+    store = _make_store(tmp_path)
+    mock_config = _mock_closed_retention("7d")
+    now = datetime(2026, 6, 16, 12, 0, tzinfo=timezone.utc)
+
+    try:
+        repeating_shift = {
+            "id": "daily",
+            "start": "2020-01-01T10:00:00Z",
+            "end": "2020-01-01T12:00:00Z",
+            "repeat": "daily",
+            "repeatEnd": None,
+            "steps": [{"user": "oncall"}],
+        }
+        store.save_shifts("primary", [repeating_shift])
+
+        removed = store.prune_expired_shifts("primary", now)
+        assert removed == 0
+        assert len(store.load_shifts("primary")) == 1
+    finally:
+        mock_config.stop()
+
+
+def test_prune_expired_shifts_removes_repeating_shift_with_past_repeat_end(tmp_path: Path):
+    store = _make_store(tmp_path)
+    mock_config = _mock_closed_retention("7d")
+    now = datetime(2026, 6, 16, 12, 0, tzinfo=timezone.utc)
+
+    try:
+        ended_repeat = {
+            "id": "ended",
+            "start": "2026-05-01T10:00:00Z",
+            "end": "2026-05-01T12:00:00Z",
+            "repeat": "daily",
+            "repeatEnd": "2026-05-05T12:00:00Z",
+            "steps": [{"user": "alice"}],
+        }
+        _write_shifts_unfiltered(store, "primary", [ended_repeat])
+
+        removed = store.prune_expired_shifts("primary", now)
+        assert removed == 1
+        assert store.load_shifts("primary") == []
+    finally:
+        mock_config.stop()
+
+
+def test_save_shifts_filters_expired_shifts(tmp_path: Path):
+    store = _make_store(tmp_path)
+    mock_config = _mock_closed_retention("7d")
+    fixed_now = datetime(2026, 6, 16, 12, 0, tzinfo=timezone.utc)
+
+    try:
+        old_shift = {
+            "id": "old",
+            "start": "2026-01-01T10:00:00Z",
+            "end": "2026-01-01T12:00:00Z",
+            "steps": [{"user": "alice"}],
+        }
+        recent_shift = {
+            "id": "recent",
+            "start": "2026-06-10T10:00:00Z",
+            "end": "2026-06-10T12:00:00Z",
+            "steps": [{"user": "bob"}],
+        }
+
+        def filter_at_fixed_now(shifts, now=None):
+            return UIChainsStore.filter_retained_shifts(store, shifts, fixed_now)
+
+        store.filter_retained_shifts = filter_at_fixed_now
+        store.save_shifts("primary", [old_shift, recent_shift])
+
+        remaining = store.load_shifts("primary")
+        assert len(remaining) == 1
+        assert remaining[0]["id"] == "recent"
+    finally:
+        mock_config.stop()
+
+
+def test_prune_all_prunes_multiple_chain_files(tmp_path: Path):
+    store = _make_store(tmp_path)
+    mock_config = _mock_closed_retention("7d")
+    now = datetime(2026, 6, 16, 12, 0, tzinfo=timezone.utc)
+
+    try:
+        old_shift = {
+            "id": "old",
+            "start": "2026-01-01T10:00:00Z",
+            "end": "2026-01-01T12:00:00Z",
+            "steps": [{"user": "alice"}],
+        }
+        _write_shifts_unfiltered(store, "primary", [old_shift])
+        _write_shifts_unfiltered(store, "backup", [old_shift])
+
+        removed = store.prune_all(now)
+        assert removed == 2
+        assert store.load_shifts("primary") == []
+        assert store.load_shifts("backup") == []
+    finally:
+        mock_config.stop()


### PR DESCRIPTION
This update introduces methods for pruning expired shifts in the UIChainsStore, enhancing memory management by removing outdated data. The `prune_expired_shifts` and `prune_all` methods have been added to facilitate this process. Additionally, the lifespan and routes have been updated to call these new methods, ensuring that expired shifts are regularly cleaned up during application operation. Tests have been added to verify the correct functionality of the pruning logic and its integration with the overall system.