### PR TITLE
481 UI chain should set first day of week based on generalweek start

### DIFF
--- a/static/js/chains.js
+++ b/static/js/chains.js
@@ -1,5 +1,5 @@
 import {getSocket} from "./websocket.js";
-import {getBaseUrl} from "./utils.js";
+import {getBaseUrl, parseWeekStart} from "./utils.js";
 import {getIsAuthenticated, onAuthChange} from "./auth.js";
 import {
     setTimezoneMode,
@@ -565,16 +565,11 @@ function generateId() {
 }
 
 async function loadChainsConfig() {
-    try {
-        const response = await fetch(`${getBaseUrl()}/chains_config`);
-        if (response.ok) {
-            chainsConfig = await response.json();
-        } else {
-            console.error('Failed to load chains config, status:', response.status);
-        }
-    } catch (error) {
-        console.error('Failed to load chains config:', error);
+    const response = await fetch(`${getBaseUrl()}/chains_config`, {credentials: "same-origin"});
+    if (!response.ok) {
+        throw new Error(`Failed to load chains config, status: ${response.status}`);
     }
+    chainsConfig = await response.json();
 }
 
 function createStepElement(step = null, index = null) {
@@ -1328,19 +1323,6 @@ async function deleteChain() {
     }
 }
 
-function parseWeekStart(weekStart) {
-    const weekStartMap = {
-        'Mon': 1, '1': 1,
-        'Tue': 2, '2': 2,
-        'Wed': 3, '3': 3,
-        'Thu': 4, '4': 4,
-        'Fri': 5, '5': 5,
-        'Sat': 6, '6': 6,
-        'Sun': 0, '0': 0, '7': 0
-    };
-    return weekStartMap[weekStart] || 1;
-}
-
 function getEffectiveTimezone() {
     return effectiveTimezone(chainsConfig.timezone, chainsConfig.user_timezone);
 }
@@ -1403,7 +1385,6 @@ function applySharedCalendarOptions() {
     for (const cal of [calendar, monthCalendar]) {
         cal.setOption('firstDay', firstDay);
         cal.setOption('timeZone', timezone);
-        cal.setOption('weekNumberCalculation', 'local');
     }
 }
 
@@ -1543,7 +1524,6 @@ function getSharedCalendarOptions(firstDay, timezone) {
         firstDay: firstDay,
         timeZone: timezone,
         weekNumbers: true,
-        weekNumberCalculation: 'local',
     };
 }
 

--- a/static/js/chains.js
+++ b/static/js/chains.js
@@ -1397,15 +1397,21 @@ function updateTimezoneSelector() {
     syncTimezoneSelects(chainsConfig.timezone, chainsConfig.messenger_type, chainsConfig.user_timezone);
 }
 
-async function updateCalendarTimezone() {
-    if (!calendar || !monthCalendar) return;
+function applySharedCalendarOptions() {
+    const firstDay = parseWeekStart(chainsConfig.week_start);
+    const timezone = getEffectiveTimezone();
+    for (const cal of [calendar, monthCalendar]) {
+        cal.setOption('firstDay', firstDay);
+        cal.setOption('timeZone', timezone);
+        cal.setOption('weekNumberCalculation', 'local');
+    }
+}
 
+async function updateCalendarTimezone() {
     const timegridScroller = document.querySelector('#calendar .fc-timegrid-body .fc-scroller');
     const scrollTop = timegridScroller ? timegridScroller.scrollTop : 0;
     
-    const timezone = getEffectiveTimezone();
-    calendar.setOption('timeZone', timezone);
-    monthCalendar.setOption('timeZone', timezone);
+    applySharedCalendarOptions();
     
     const chains = await loadChains();
     refreshCalendarEvents(getExpandedChains(chains));
@@ -1420,21 +1426,10 @@ async function updateCalendarTimezone() {
     }
 }
 
-function getWeekNumber(date) {
-    const d = new Date(date);
-    d.setHours(0, 0, 0, 0);
-    d.setDate(d.getDate() + 3 - (d.getDay() + 6) % 7);
-    const week1 = new Date(d.getFullYear(), 0, 4);
-    week1.setHours(0, 0, 0, 0);
-    week1.setDate(week1.getDate() + 3 - (week1.getDay() + 6) % 7);
-    return 1 + Math.round(((d.getTime() - week1.getTime()) / 86400000) / 7);
-}
-
 function updateWeekNumberDisplay() {
     if (!calendar) return;
     
-    const weekStart = calendar.view.currentStart;
-    const weekNumber = getWeekNumber(weekStart);
+    const weekNumber = calendar.view.dateEnv.computeWeekNumber(calendar.view.currentStart);
     const weekNumberDisplay = document.getElementById('week-number-display');
     
     if (weekNumberDisplay) {
@@ -1548,7 +1543,7 @@ function getSharedCalendarOptions(firstDay, timezone) {
         firstDay: firstDay,
         timeZone: timezone,
         weekNumbers: true,
-        weekNumberCalculation: 'ISO',
+        weekNumberCalculation: 'local',
     };
 }
 
@@ -1763,9 +1758,7 @@ async function initializeCalendars() {
         if (initialized && calendar && monthCalendar) {
             console.log('Calendars already initialized, re-rendering');
             updateTimezoneSelector();
-            const timezone = getEffectiveTimezone();
-            calendar.setOption('timeZone', timezone);
-            monthCalendar.setOption('timeZone', timezone);
+            applySharedCalendarOptions();
             calendar.render();
             monthCalendar.render();
             
@@ -1901,7 +1894,9 @@ export const ChainsManager = {
             timezoneSelect.addEventListener('change', async (e) => {
                 setTimezoneMode(e.target.value);
                 syncTimezoneSelects(chainsConfig.timezone, chainsConfig.messenger_type, chainsConfig.user_timezone);
-                await updateCalendarTimezone();
+                if (calendar && monthCalendar) {
+                    await updateCalendarTimezone();
+                }
             });
         }
 

--- a/static/js/maintenance.js
+++ b/static/js/maintenance.js
@@ -1,4 +1,4 @@
-import {getBaseUrl} from "./utils.js";
+import {getBaseUrl, parseWeekStart} from "./utils.js";
 import {createEditableFilterBadge, validateAndFormatFilter} from "./filters.js";
 import {getIsAuthenticated, onAuthChange} from "./auth.js";
 import {
@@ -13,6 +13,7 @@ let rowSeq = 0;
 let pickerMode = null;
 let pickerTargetId = null;
 let configTimezone = "UTC";
+let configWeekStart = "Mon";
 let messengerType = "";
 let userTimezone = null;
 let activeIndicatorTimer = null;
@@ -262,17 +263,15 @@ function commitParsedRowInputs(row, parsed) {
 }
 
 async function loadChainsConfig() {
-    try {
-        const res = await fetch(`${getBaseUrl()}/chains_config`, {credentials: "same-origin"});
-        if (res.ok) {
-            const data = await res.json();
-            configTimezone = data.timezone || "UTC";
-            messengerType = data.messenger_type || "";
-            userTimezone = data.user_timezone || null;
-        }
-    } catch (e) {
-        console.warn("Failed to load chains config for maintenance timezone", e);
+    const res = await fetch(`${getBaseUrl()}/chains_config`, {credentials: "same-origin"});
+    if (!res.ok) {
+        throw new Error(`Failed to load chains config, status: ${res.status}`);
     }
+    const data = await res.json();
+    configTimezone = data.timezone;
+    configWeekStart = data.week_start;
+    messengerType = data.messenger_type;
+    userTimezone = data.user_timezone;
 }
 
 function rowFromServer(data) {
@@ -786,7 +785,7 @@ function openIntervalPickerUi(initialStart, initialDurationMs) {
         initialView: "timeGridWeek",
         initialDate: initialStart,
         headerToolbar: {left: "title", center: "", right: "today prev,next"},
-        firstDay: 1,
+        firstDay: parseWeekStart(configWeekStart),
         height: "100%",
         scrollTime: scrollTimeFromDate(initialStart),
         scrollTimeReset: false,
@@ -806,7 +805,6 @@ function openIntervalPickerUi(initialStart, initialDurationMs) {
             hour12: false,
         },
         weekNumbers: true,
-        weekNumberCalculation: "ISO",
         events: [],
         select(info) {
             const ms = info.end.getTime() - info.start.getTime();

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -22,5 +22,21 @@ function getBaseUrl() {
     return pathSegments.length > 0 ? '/' + pathSegments.join('/') : '';
 }
 
+function parseWeekStart(weekStart) {
+    const weekStartMap = {
+        'Mon': 1, '1': 1,
+        'Tue': 2, '2': 2,
+        'Wed': 3, '3': 3,
+        'Thu': 4, '4': 4,
+        'Fri': 5, '5': 5,
+        'Sat': 6, '6': 6,
+        'Sun': 0, '0': 0, '7': 0
+    };
+    if (!(weekStart in weekStartMap)) {
+        throw new Error(`Invalid week_start: ${weekStart}`);
+    }
+    return weekStartMap[weekStart];
+}
+
 // Export for use in other modules
-export { getBaseUrl };
+export { getBaseUrl, parseWeekStart };


### PR DESCRIPTION
This pull request refactors how week start configuration and timezone options are handled in the calendar and maintenance modules. The main improvements include centralizing the `parseWeekStart` utility, ensuring consistent use of configuration values from the backend, and simplifying calendar option updates. Error handling for configuration loading has also been improved.

**Refactoring and Utility Improvements:**

* Moved the `parseWeekStart` function from `chains.js` to `utils.js` for reuse across modules, and updated imports accordingly. Added validation to throw an error on invalid input. (`static/js/chains.js`, `static/js/maintenance.js`, `static/js/utils.js`) [[1]](diffhunk://#diff-671a33d2cb7f4d7be3dcaecba8c118e0572ecf9fedb80fc098c405dfb26f9a3dL2-R2) [[2]](diffhunk://#diff-9f787e7616e83d1b685849eaec897d327f369b90f8d121d091b3329867f0803cL1-R1) [[3]](diffhunk://#diff-4b1715a790893af26d0fa0b40b70f38d9be2de9e75e0d5fa7573c78b5ef8e3d9R25-R42)
* Updated all calendar initializations and updates to use the shared `parseWeekStart` utility and configuration values from the backend, replacing hardcoded values. (`static/js/chains.js`, `static/js/maintenance.js`) [[1]](diffhunk://#diff-671a33d2cb7f4d7be3dcaecba8c118e0572ecf9fedb80fc098c405dfb26f9a3dL1400-R1395) [[2]](diffhunk://#diff-9f787e7616e83d1b685849eaec897d327f369b90f8d121d091b3329867f0803cL789-R788)

**Configuration Loading and Error Handling:**

* Refactored `loadChainsConfig` in both `chains.js` and `maintenance.js` to use consistent error handling: now throws an error if the fetch fails, and always uses the backend-provided values for timezone and week start. (`static/js/chains.js`, `static/js/maintenance.js`) [[1]](diffhunk://#diff-671a33d2cb7f4d7be3dcaecba8c118e0572ecf9fedb80fc098c405dfb26f9a3dL568-R572) [[2]](diffhunk://#diff-9f787e7616e83d1b685849eaec897d327f369b90f8d121d091b3329867f0803cL265-R274)

**Calendar Option Management:**

* Introduced the `applySharedCalendarOptions` function to DRY up calendar timezone and week start updates, ensuring both `calendar` and `monthCalendar` are updated together. (`static/js/chains.js`) [[1]](diffhunk://#diff-671a33d2cb7f4d7be3dcaecba8c118e0572ecf9fedb80fc098c405dfb26f9a3dL1400-R1395) [[2]](diffhunk://#diff-671a33d2cb7f4d7be3dcaecba8c118e0572ecf9fedb80fc098c405dfb26f9a3dL1766-R1741)

**Simplification and Consistency:**

* Removed custom week number calculation in favor of the calendar library’s built-in method, and removed redundant or hardcoded calendar options (`weekNumberCalculation`). (`static/js/chains.js`, `static/js/maintenance.js`) [[1]](diffhunk://#diff-671a33d2cb7f4d7be3dcaecba8c118e0572ecf9fedb80fc098c405dfb26f9a3dL1423-R1413) [[2]](diffhunk://#diff-671a33d2cb7f4d7be3dcaecba8c118e0572ecf9fedb80fc098c405dfb26f9a3dL1551) [[3]](diffhunk://#diff-9f787e7616e83d1b685849eaec897d327f369b90f8d121d091b3329867f0803cL809)

These changes improve maintainability, reduce duplication, and ensure calendar settings are consistently derived from backend configuration.