### PR TITLE
Implement maintenance window scheduling and cleanup enhancements

### DIFF
--- a/app/im/mattermost/threads.py
+++ b/app/im/mattermost/threads.py
@@ -96,11 +96,7 @@ def _build_mattermost_actions(incident, user_timezone='UTC'):
     }]
     
     if incident.frozen_by_maintenance:
-        freeze_text = (
-            format_freeze_expiration(incident.frozen_until, user_timezone)
-            if incident.frozen_until
-            else 'Maintenance'
-        )
+        freeze_text = 'Maintenance'
         actions.append({
             "id": "freeze",
             "type": "button",

--- a/app/im/slack/threads.py
+++ b/app/im/slack/threads.py
@@ -80,11 +80,7 @@ def _build_slack_actions(incident, tz_str: str = "UTC"):
     ]
     
     if incident.frozen_by_maintenance:
-        freeze_text = (
-            format_freeze_expiration(incident.frozen_until, tz_str)
-            if incident.frozen_until
-            else 'Maintenance'
-        )
+        freeze_text = 'Maintenance'
         actions.append({
             "name": 'freeze',
             "type": 'button',

--- a/app/im/telegram/telegram_application.py
+++ b/app/im/telegram/telegram_application.py
@@ -191,13 +191,7 @@ class TelegramApplication(Application):
                 chain_button = buttons['chain']['assigned']
 
         if incident.frozen_by_maintenance:
-            telegram_tz = config_obj.app.general.timezone
-            freeze_text = (
-                format_freeze_expiration(incident.frozen_until, telegram_tz)
-                if incident.frozen_until
-                else 'Maintenance'
-            )
-            freeze_button = {'text': freeze_text, 'callback_data': 'noop'}
+            freeze_button = {'text': 'Maintenance', 'callback_data': 'noop'}
         elif incident.frozen_by_inhibition:
             freeze_button = buttons['freeze']['inhibited']
         elif incident.can_manual_unfreeze():

--- a/app/incident/incident.py
+++ b/app/incident/incident.py
@@ -525,7 +525,7 @@ async def remove_freeze_source(
     parent: Optional[str] = None,
     notify: bool = False,
 ):
-    if not incident.is_frozen() and source not in (FreezeSource.PARENT, FreezeSource.MAINTENANCE):
+    if not incident.is_frozen() and source != FreezeSource.PARENT:
         logger.info(f'Incident {incident.uuid} is not frozen, skipping unfreeze')
         return
 

--- a/app/lifespan.py
+++ b/app/lifespan.py
@@ -87,6 +87,7 @@ async def create_main_objects(fastapi_app: FastAPI, reload=False):
         await user_scheduler.schedule_all_stored()
         queue_manager = AsyncQueueManager(queue, messenger, incidents, webhooks, route, inhibition_manager, maintenance_manager)
         await maintenance_manager.reconcile_all()
+        await maintenance_manager.schedule_window_starts()
         ui_chains_store.prune_all()
         get_maintenance_store().prune_expired_windows()
 

--- a/app/maintenance/manager.py
+++ b/app/maintenance/manager.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Callable, List, Optional, TYPE_CHECKING
+from typing import Callable, List, Optional, TYPE_CHECKING, Tuple
 
 from app.logging import logger
 from app.maintenance.models import MaintenanceWindow
@@ -40,85 +40,134 @@ class MaintenanceManager:
         self.queue = queue
         self._now = now or (lambda: datetime.now(timezone.utc))
 
-    def _active_sorted(self, now: Optional[datetime] = None) -> List[MaintenanceWindow]:
-        now = now or self._now()
-        active = [w for w in self.store.list() if w.is_active(now)]
+    def _first_matching_window_with_coverage_end(
+        self, incident: "Incident", require_future_end: bool = False
+    ) -> Optional[Tuple[MaintenanceWindow, datetime]]:
+        now = self._now()
+        windows = self.store.list()
+        active = [w for w in windows if w.is_active(now)]
         active.sort(key=lambda w: (w.starts_at, w.ends_at, w.id))
-        return active
+        for window in active:
+            if require_future_end and window.ends_at <= now:
+                continue
+            if window.matches_incident(incident):
+                return window, self._continuous_matching_end(incident, window, windows)
+        return None
 
     def _first_matching_window(
         self, incident: "Incident", require_future_end: bool = False
     ) -> Optional[MaintenanceWindow]:
-        now = self._now()
-        for window in self._active_sorted(now):
-            if require_future_end and window.ends_at <= now:
-                continue
-            if window.matches_incident(incident):
-                return window
-        return None
+        match = self._first_matching_window_with_coverage_end(incident, require_future_end)
+        return match[0] if match else None
+
+    @staticmethod
+    def _continuous_matching_end(
+        incident: "Incident", initial_window: MaintenanceWindow, windows: List[MaintenanceWindow]
+    ) -> datetime:
+        coverage_end = initial_window.ends_at
+        candidates = sorted(windows, key=lambda w: (w.starts_at, w.ends_at, w.id))
+
+        extended = True
+        while extended:
+            extended = False
+            for window in candidates:
+                if window.ends_at <= coverage_end:
+                    continue
+                if window.starts_at > coverage_end:
+                    continue
+                if not window.matches_incident(incident):
+                    continue
+                coverage_end = window.ends_at
+                extended = True
+
+        return coverage_end
 
     def would_match_active_window(self, incident: "Incident") -> bool:
         return self._first_matching_window(incident) is not None
 
+    async def schedule_window_starts(self):
+        now = self._now()
+        await self.queue.delete_by_type(QueueItemType.MAINTENANCE_START)
+        for window in self.store.list():
+            if window.starts_at > now:
+                await self.queue.put(
+                    window.starts_at,
+                    QueueItemType.MAINTENANCE_START,
+                    identifier=window.id,
+                )
+
+    async def handle_window_start(self, _window_id: Optional[str]):
+        await self.reconcile_all()
+
     async def process_incident(self, incident: "Incident"):
-        window = self._first_matching_window(incident)
-        if window is None:
+        match = self._first_matching_window_with_coverage_end(incident)
+        if match is None:
             return
+        window, coverage_end = match
 
         was_frozen = incident.is_frozen()
         incident.set_maintenance_parent()
 
         if was_frozen:
+            await self._schedule_maintenance_freeze(incident, coverage_end)
             logger.info(
                 "Maintenance source recorded on frozen incident",
-                extra={"uuid": incident.uuid, "window_id": window.id, "until": window.ends_at},
+                extra={"uuid": incident.uuid, "window_id": window.id, "until": coverage_end},
             )
             if incident.ts:
                 await self.application.update_incident_message(incident)
             return
 
         await self.application.apply_time_freeze(
-            incident, window.ends_at, user=None, queue_=self.queue, source=FreezeSource.MAINTENANCE
+            incident, coverage_end, user=None, queue_=self.queue, source=FreezeSource.MAINTENANCE
         )
         logger.info(
             "Maintenance time freeze applied",
-            extra={"uuid": incident.uuid, "window_id": window.id, "until": window.ends_at},
+            extra={"uuid": incident.uuid, "window_id": window.id, "until": coverage_end},
         )
         if incident.ts:
             await self.application.update_incident_message(incident)
 
-    async def reconcile_incident(self, incident: "Incident", update_message: bool = True):
+    async def _schedule_maintenance_freeze(self, incident: "Incident", coverage_end: datetime):
+        if incident.frozen_until_source in (None, FreezeSource.MAINTENANCE.value):
+            incident.frozen_until = coverage_end
+            incident.frozen_until_source = FreezeSource.MAINTENANCE.value
+        incident.chain_enabled = False
+        incident.dump()
+
+        await self.queue.delete_by_id_type_and_data(
+            incident.uniq_id,
+            QueueItemType.UNFREEZE,
+            FreezeSource.MAINTENANCE.value,
+        )
+        await self.queue.put(
+            coverage_end,
+            QueueItemType.UNFREEZE,
+            incident.uniq_id,
+            data=FreezeSource.MAINTENANCE.value,
+        )
+
+    async def reconcile_incident(
+        self, incident: "Incident", update_message: bool = True, notify_removed: bool = False
+    ):
         """Recalculate this incident's maintenance source and time-freeze schedule."""
-        window = self._first_matching_window(incident, require_future_end=True)
-        if window is None:
+        match = self._first_matching_window_with_coverage_end(incident, require_future_end=True)
+        if match is None:
             await remove_freeze_source(
-                incident, self.application, self.queue, source=FreezeSource.MAINTENANCE, notify=False
+                incident, self.application, self.queue, source=FreezeSource.MAINTENANCE, notify=notify_removed
             )
             if update_message and incident.ts:
                 await self.application.update_incident_message(incident)
             return
+        window, coverage_end = match
 
-        had_maintenance = MAINTENANCE_PARENT_SENTINEL in incident.parents
-        was_frozen = incident.is_frozen()
         incident.set_maintenance_parent()
-        if not was_frozen or had_maintenance:
-            incident.frozen_until = window.ends_at
-            incident.frozen_until_source = FreezeSource.MAINTENANCE.value
-            incident.chain_enabled = False
-            incident.dump()
+        await self._schedule_maintenance_freeze(incident, coverage_end)
 
-            await self.queue.delete_by_id_and_type(incident.uniq_id, QueueItemType.UNFREEZE)
-            await self.queue.put(
-                window.ends_at,
-                QueueItemType.UNFREEZE,
-                incident.uniq_id,
-                data=FreezeSource.MAINTENANCE.value,
-            )
-
-            logger.info(
-                "Maintenance time freeze scheduled",
-                extra={"uuid": incident.uuid, "window_id": window.id, "until": window.ends_at},
-            )
+        logger.info(
+            "Maintenance time freeze scheduled",
+            extra={"uuid": incident.uuid, "window_id": window.id, "until": coverage_end},
+        )
 
         if update_message and incident.ts:
             await self.application.update_incident_message(incident)

--- a/app/queue/constants.py
+++ b/app/queue/constants.py
@@ -10,6 +10,7 @@ class QueueItemType:
     ALERT = 'alert'
     UNFREEZE = 'unfreeze'
     UPDATE_USER = 'update_user'
+    MAINTENANCE_START = 'maintenance_start'
 
 
 USER_UPDATE_GAP_SECONDS = {

--- a/app/queue/handlers/unfreeze_handler.py
+++ b/app/queue/handlers/unfreeze_handler.py
@@ -32,7 +32,11 @@ class UnfreezeHandler(BaseHandler):
             return
 
         freeze_source = FreezeSource(source)
-        if incident.frozen_until_source != freeze_source.value:
+        if freeze_source == FreezeSource.MAINTENANCE:
+            source_active = incident.frozen_by_maintenance
+        else:
+            source_active = incident.frozen_until_source == freeze_source.value
+        if not source_active:
             logger.info(
                 "Ignoring stale unfreeze event",
                 extra={

--- a/app/queue/manager.py
+++ b/app/queue/manager.py
@@ -50,6 +50,9 @@ class AsyncQueueManager:
     async def handle_unfreeze(self, uniq_id: str, data: str):
         await self.unfreeze_handler.handle(uniq_id, data)
 
+    async def handle_maintenance_start(self, window_id: str):
+        await self.maintenance_manager.handle_window_start(window_id)
+
     async def handle_user_update(self, user_id: str):
         await self.user_update_handler.handle(user_id)
 
@@ -71,6 +74,8 @@ class AsyncQueueManager:
                 await self.handle_alert(data)
             elif type_ == QueueItemType.UNFREEZE:
                 await self.handle_unfreeze(uniq_id, data)
+            elif type_ == QueueItemType.MAINTENANCE_START:
+                await self.handle_maintenance_start(identifier)
             elif type_ == QueueItemType.UPDATE_USER:
                 await self.handle_user_update(identifier)
         except Exception as e:

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -26,6 +26,16 @@ class AsyncQueue:
         async with self._lock:
             self._delete_by_id_and_type_internal(uniq_id, type_)
 
+    async def delete_by_id_type_and_data(self, uniq_id: str, type_: str, data: Any):
+        """Delete items by incident uniq_id, type, and payload data."""
+        async with self._lock:
+            self._delete_by_id_type_and_data_internal(uniq_id, type_, data)
+
+    async def delete_by_type(self, type_: str):
+        """Delete all items of a specific type."""
+        async with self._lock:
+            self._delete_by_type_internal(type_)
+
     async def get_first_item_datetime(self) -> Optional[datetime]:
         """Get datetime of the next item that's ready to be processed (if any)."""
         async with self._lock:
@@ -154,6 +164,17 @@ class AsyncQueue:
             item for item in self._items
             if not (item.uniq_id == uniq_id and item.type == type_)
         ]
+
+    def _delete_by_id_type_and_data_internal(self, uniq_id: str, type_: str, data: Any):
+        """Internal delete by id, type, and data method that doesn't acquire lock."""
+        self._items = [
+            item for item in self._items
+            if not (item.uniq_id == uniq_id and item.type == type_ and item.data == data)
+        ]
+
+    def _delete_by_type_internal(self, type_: str):
+        """Internal delete by type method that doesn't acquire lock."""
+        self._items = [item for item in self._items if item.type != type_]
 
     def _insert_item_sorted(self, new_item: QueueItem):
         """Insert item in sorted order by datetime"""

--- a/app/routes.py
+++ b/app/routes.py
@@ -424,6 +424,7 @@ def create_router(http_prefix: str, fastapi_app: FastAPI = None, auth_manager=No
                                         removed_window = MaintenanceWindow.from_window_dict(window_dict)
                                         await maintenance_manager.reconcile_after_window_removed(removed_window)
                                     await maintenance_manager.reconcile_all()
+                                    await maintenance_manager.schedule_window_starts()
                                 await websocket.send_text(json.dumps({
                                     "event": "maintenance_saved",
                                     "success": success,

--- a/templates/mattermost_body.j2
+++ b/templates/mattermost_body.j2
@@ -30,13 +30,12 @@ _{{ commonAnnotations.description }}_{% endif %}
     {{ k }}=`{{ v }}`
 {%- endfor -%}
 {% endif -%}
-{%- if incident.parents | length > 0 %}
+{%- set parent_incidents = incident.parents | reject("equalto", "maintenance") | list -%}
+{%- if parent_incidents | length > 0 %}
 
-**Parent sources:**
-{%- for parent_id in incident.parents %}
-{%- if parent_id == "maintenance" %}
-    Maintenance
-{%- elif parent_id in incidents.uniq_ids %}
+**Parent incidents:**
+{%- for parent_id in parent_incidents %}
+{%- if parent_id in incidents.uniq_ids %}
     [{{ incidents.uniq_ids[parent_id].payload.commonLabels.alertname }}]({{ incidents.uniq_ids[parent_id].link | urlencode }})
 {%- else %}
     {{ parent_id }}

--- a/templates/slack_body.j2
+++ b/templates/slack_body.j2
@@ -30,13 +30,12 @@ _{{ commonAnnotations.description }}_{% endif %}
     {{ k }}=`{{ v }}`
 {%- endfor -%}
 {% endif -%}
-{%- if incident.parents | length > 0 %}
+{%- set parent_incidents = incident.parents | reject("equalto", "maintenance") | list -%}
+{%- if parent_incidents | length > 0 %}
 
-*Parent sources:*
-{%- for parent_id in incident.parents %}
-{%- if parent_id == "maintenance" %}
-    Maintenance
-{%- elif parent_id in incidents.uniq_ids %}
+*Parent incidents:*
+{%- for parent_id in parent_incidents %}
+{%- if parent_id in incidents.uniq_ids %}
     <{{ incidents.uniq_ids[parent_id].link }}|{{ incidents.uniq_ids[parent_id].payload.commonLabels.alertname }}>
 {%- else %}
     {{ parent_id }}

--- a/templates/telegram_body.j2
+++ b/templates/telegram_body.j2
@@ -29,13 +29,12 @@
     {{ k }}=<code>{{ v }}</code>
 {%- endfor -%}
 {% endif -%}
-{%- if incident.parents | length > 0 %}
+{%- set parent_incidents = incident.parents | reject("equalto", "maintenance") | list -%}
+{%- if parent_incidents | length > 0 %}
 
-<b>Parent sources:</b>
-{%- for parent_id in incident.parents %}
-{%- if parent_id == "maintenance" %}
-    Maintenance
-{%- elif parent_id in incidents.uniq_ids %}
+<b>Parent incidents:</b>
+{%- for parent_id in parent_incidents %}
+{%- if parent_id in incidents.uniq_ids %}
     <a href="{{ incidents.uniq_ids[parent_id].link }}">{{ incidents.uniq_ids[parent_id].payload.commonLabels.alertname }}</a>
 {%- else %}
     {{ parent_id }}

--- a/tests/test_im/test_incident_messages.py
+++ b/tests/test_im/test_incident_messages.py
@@ -14,7 +14,10 @@ TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "templates"
 
 
 def _config(task_management=False):
-    return SimpleNamespace(app=SimpleNamespace(task_management=task_management))
+    return SimpleNamespace(
+        app=SimpleNamespace(task_management=task_management),
+        messenger=SimpleNamespace(impulse_address="https://impulse.test"),
+    )
 
 
 def _env(task_management_enabled=False):

--- a/tests/test_im/test_incident_messages.py
+++ b/tests/test_im/test_incident_messages.py
@@ -1,0 +1,114 @@
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from app.im.mattermost.threads import _build_mattermost_actions
+from app.im.slack.threads import _build_slack_actions
+from app.jinja_template import JinjaTemplate
+
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "templates"
+
+
+def _config(task_management=False):
+    return SimpleNamespace(app=SimpleNamespace(task_management=task_management))
+
+
+def _env(task_management_enabled=False):
+    return SimpleNamespace(task_management_enabled=task_management_enabled)
+
+
+def _maintenance_incident():
+    return SimpleNamespace(
+        status="firing",
+        chain_enabled=False,
+        frozen_by_inhibition=False,
+        frozen_by_maintenance=True,
+        frozen_until=datetime.now(timezone.utc) + timedelta(hours=1),
+        task_link="",
+        can_manual_unfreeze=lambda: False,
+        is_frozen=lambda: True,
+    )
+
+
+def _payload():
+    return {
+        "commonAnnotations": {},
+        "groupLabels": {},
+        "commonLabels": {},
+        "alerts": [
+            {
+                "generatorURL": "",
+                "labels": {"instance": "host-1"},
+                "annotations": {},
+            }
+        ],
+    }
+
+
+def _incident_data(parents):
+    return {
+        "task_link": "",
+        "assigned_user_id": "",
+        "assigned_user": "",
+        "parents": parents,
+        "childs": [],
+    }
+
+
+@pytest.mark.parametrize(
+    ("builder", "config_patch", "env_patch", "label_key"),
+    [
+        (_build_slack_actions, "app.im.slack.threads.get_config", "app.im.slack.threads.get_environment_config", "text"),
+        (
+            _build_mattermost_actions,
+            "app.im.mattermost.threads.get_config",
+            "app.im.mattermost.threads.get_environment_config",
+            "name",
+        ),
+    ],
+)
+def test_maintenance_freeze_button_label_is_maintenance(builder, config_patch, env_patch, label_key):
+    with patch(config_patch, return_value=_config()), patch(env_patch, return_value=_env()):
+        actions = builder(_maintenance_incident(), "UTC")
+
+    freeze_action = next(action for action in actions if action.get("name") == "freeze" or action.get("id") == "freeze")
+    assert freeze_action[label_key] == "Maintenance"
+
+
+@pytest.mark.parametrize("template_name", ["slack_body.j2", "mattermost_body.j2", "telegram_body.j2"])
+def test_parent_section_hidden_for_maintenance_sentinel_only(template_name):
+    template = JinjaTemplate((TEMPLATES_DIR / template_name).read_text())
+    incident = SimpleNamespace(serialize=lambda: _incident_data(["maintenance"]))
+    JinjaTemplate.set_incidents(SimpleNamespace(uniq_ids={}))
+    try:
+        rendered = template.form_message(_payload(), incident)
+    finally:
+        JinjaTemplate.set_incidents(None)
+
+    assert "Parent incidents" not in rendered
+    assert "Parent sources" not in rendered
+    assert "Maintenance" not in rendered
+
+
+@pytest.mark.parametrize("template_name", ["slack_body.j2", "mattermost_body.j2", "telegram_body.j2"])
+def test_parent_section_shows_only_real_parent_incidents(template_name):
+    template = JinjaTemplate((TEMPLATES_DIR / template_name).read_text())
+    incident = SimpleNamespace(serialize=lambda: _incident_data(["maintenance", "parent-1"]))
+    parent = SimpleNamespace(
+        link="https://example.test/parent",
+        payload={"commonLabels": {"alertname": "ParentAlert"}},
+    )
+    JinjaTemplate.set_incidents(SimpleNamespace(uniq_ids={"parent-1": parent}))
+    try:
+        rendered = template.form_message(_payload(), incident)
+    finally:
+        JinjaTemplate.set_incidents(None)
+
+    assert "Parent incidents" in rendered
+    assert "Parent sources" not in rendered
+    assert "ParentAlert" in rendered
+    assert "Maintenance" not in rendered

--- a/tests/test_incident/test_freeze.py
+++ b/tests/test_incident/test_freeze.py
@@ -5,11 +5,11 @@ This module tests the freeze/unfreeze functionality added to the Incident class,
 including freezing incidents, automatic unfreezing, and freeze state checks.
 """
 from datetime import datetime, timezone, timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from app.incident.incident import Incident, IncidentConfig
+from app.incident.incident import Incident, IncidentConfig, remove_freeze_source
 from app.incident.freeze import FreezeSource
 from tests.utils import create_alert_payload
 
@@ -82,6 +82,30 @@ class TestIncidentFreeze:
         with patch.object(sample_incident, "dump"):
             sample_incident.set_maintenance_parent()
         assert sample_incident.can_manual_unfreeze() is False
+
+    @pytest.mark.asyncio
+    async def test_parent_unfreeze_restores_after_last_parent_already_removed(self, sample_incident):
+        """Inhibition cleanup removes the parent first, then calls this to restore queues."""
+        assert sample_incident.is_frozen() is False
+        app = Mock()
+        queue = Mock()
+
+        with patch("app.incident.incident.sync_after_freeze_change", new_callable=AsyncMock) as sync_after_change:
+            await remove_freeze_source(
+                sample_incident,
+                app,
+                queue,
+                source=FreezeSource.PARENT,
+                notify=False,
+            )
+
+        sync_after_change.assert_awaited_once_with(
+            sample_incident,
+            app,
+            queue,
+            "firing",
+            notify=False,
+        )
 
 class TestIncidentInhibitionFreeze:
     """Test cases for inhibition-based freeze functionality."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -49,6 +49,7 @@ class TestMainApplication:
 
             mock_maintenance_manager = Mock()
             mock_maintenance_manager.reconcile_all = AsyncMock()
+            mock_maintenance_manager.schedule_window_starts = AsyncMock()
             mock_maintenance_manager_class.return_value = mock_maintenance_manager
             
             # Setup mock config

--- a/tests/test_maintenance/test_manager.py
+++ b/tests/test_maintenance/test_manager.py
@@ -41,6 +41,14 @@ def _window(start_offset_hours=0, duration_hours=2, matchers=None):
     )
 
 
+def _fixed_window(starts_at, ends_at, matchers=None):
+    return MaintenanceWindow(
+        starts_at=starts_at,
+        ends_at=ends_at,
+        matchers=matchers or ['alertname = "TestAlert"'],
+    )
+
+
 @pytest.fixture
 def maintenance_setup():
     store = Mock()
@@ -52,6 +60,8 @@ def maintenance_setup():
     application.update_incident_message = AsyncMock()
     queue = Mock()
     queue.delete_by_id_and_type = AsyncMock()
+    queue.delete_by_id_type_and_data = AsyncMock()
+    queue.delete_by_type = AsyncMock()
     queue.delete_by_id = AsyncMock()
     queue.put = AsyncMock()
     queue.put_first = AsyncMock()
@@ -61,6 +71,35 @@ def maintenance_setup():
 
 
 class TestMaintenanceManager:
+    @pytest.mark.asyncio
+    async def test_schedule_window_starts_queues_future_windows(self, maintenance_setup):
+        manager, store, _, queue = maintenance_setup
+        active = _fixed_window(TEST_NOW - timedelta(hours=1), TEST_NOW + timedelta(hours=1))
+        future = _fixed_window(TEST_NOW + timedelta(minutes=5), TEST_NOW + timedelta(hours=2))
+        store.list.return_value = [future, active]
+
+        await manager.schedule_window_starts()
+
+        queue.delete_by_type.assert_awaited_once_with(QueueItemType.MAINTENANCE_START)
+        queue.put.assert_awaited_once_with(
+            future.starts_at,
+            QueueItemType.MAINTENANCE_START,
+            identifier=future.id,
+        )
+
+    @pytest.mark.asyncio
+    async def test_handle_window_start_reconciles_when_window_is_active(self, maintenance_setup):
+        manager, store, _, _ = maintenance_setup
+        window = _window()
+        store.list.return_value = [window]
+        incident = _incident()
+        manager.incidents.uniq_ids = {incident.uniq_id: incident}
+
+        await manager.handle_window_start(window.id)
+
+        assert incident.frozen_until == window.ends_at
+        assert incident.frozen_until_source == FreezeSource.MAINTENANCE.value
+
     @pytest.mark.asyncio
     async def test_process_incident_applies_freeze_when_window_matches(self, maintenance_setup):
         manager, store, application, _ = maintenance_setup
@@ -93,9 +132,24 @@ class TestMaintenanceManager:
         application.update_incident_message.assert_awaited_once_with(incident)
 
     @pytest.mark.asyncio
+    async def test_process_incident_freezes_until_connected_matching_window_end(self, maintenance_setup):
+        manager, store, application, _ = maintenance_setup
+        first = _fixed_window(TEST_NOW - timedelta(hours=1), TEST_NOW + timedelta(hours=1))
+        second = _fixed_window(first.ends_at, first.ends_at + timedelta(hours=2))
+        store.list.return_value = [first, second]
+        incident = _incident()
+
+        await manager.process_incident(incident)
+
+        application.apply_time_freeze.assert_awaited_once_with(
+            incident, second.ends_at, user=None, queue_=manager.queue, source=FreezeSource.MAINTENANCE
+        )
+
+    @pytest.mark.asyncio
     async def test_process_incident_defers_when_inhibition_holds(self, maintenance_setup):
         manager, store, application, _ = maintenance_setup
-        store.list.return_value = [_window()]
+        window = _window()
+        store.list.return_value = [window]
         incident = _incident()
         incident.parents.append("source-uniq-id")
 
@@ -103,6 +157,14 @@ class TestMaintenanceManager:
 
         assert MAINTENANCE_PARENT_SENTINEL in incident.parents
         assert incident.frozen_by_maintenance is True
+        assert incident.frozen_until == window.ends_at
+        assert incident.frozen_until_source == FreezeSource.MAINTENANCE.value
+        manager.queue.put.assert_awaited_once_with(
+            window.ends_at,
+            QueueItemType.UNFREEZE,
+            incident.uniq_id,
+            data=FreezeSource.MAINTENANCE.value,
+        )
         application.apply_time_freeze.assert_not_called()
         application.update_incident_message.assert_not_called()
 
@@ -122,6 +184,48 @@ class TestMaintenanceManager:
         assert incident.frozen_by_maintenance is True
         application.apply_time_freeze.assert_not_called()
         application.update_incident_message.assert_awaited_once_with(incident)
+
+    @pytest.mark.asyncio
+    async def test_reconcile_schedules_maintenance_for_inhibited_incident(self, maintenance_setup):
+        manager, store, _, _ = maintenance_setup
+        window = _window()
+        store.list.return_value = [window]
+        incident = _incident()
+        incident.parents = ["source-uniq-id"]
+
+        await manager.reconcile_incident(incident)
+
+        assert MAINTENANCE_PARENT_SENTINEL in incident.parents
+        assert incident.frozen_until == window.ends_at
+        assert incident.frozen_until_source == FreezeSource.MAINTENANCE.value
+        manager.queue.put.assert_awaited_once_with(
+            window.ends_at,
+            QueueItemType.UNFREEZE,
+            incident.uniq_id,
+            data=FreezeSource.MAINTENANCE.value,
+        )
+
+    @pytest.mark.asyncio
+    async def test_reconcile_preserves_manual_freeze_when_maintenance_starts(self, maintenance_setup):
+        manager, store, _, _ = maintenance_setup
+        window = _window()
+        store.list.return_value = [window]
+        incident = _incident()
+        manual_until = TEST_NOW + timedelta(hours=4)
+        incident.frozen_until = manual_until
+        incident.frozen_until_source = FreezeSource.TIME.value
+
+        await manager.reconcile_incident(incident)
+
+        assert MAINTENANCE_PARENT_SENTINEL in incident.parents
+        assert incident.frozen_until == manual_until
+        assert incident.frozen_until_source == FreezeSource.TIME.value
+        manager.queue.put.assert_awaited_once_with(
+            window.ends_at,
+            QueueItemType.UNFREEZE,
+            incident.uniq_id,
+            data=FreezeSource.MAINTENANCE.value,
+        )
 
     @pytest.mark.asyncio
     async def test_reconcile_clears_sentinel_when_no_active_window(self, maintenance_setup):
@@ -220,6 +324,27 @@ class TestMaintenanceManager:
             data=FreezeSource.MAINTENANCE.value,
         )
         application.update_incident_message.assert_awaited_once_with(incident)
+
+    @pytest.mark.asyncio
+    async def test_reconcile_reschedules_to_connected_matching_window_end(self, maintenance_setup):
+        manager, store, _, _ = maintenance_setup
+        first = _fixed_window(TEST_NOW - timedelta(hours=1), TEST_NOW + timedelta(hours=1))
+        second = _fixed_window(first.ends_at, first.ends_at + timedelta(hours=2))
+        store.list.return_value = [second, first]
+        incident = _incident()
+        incident.parents = [MAINTENANCE_PARENT_SENTINEL]
+        incident.frozen_until = first.ends_at
+        incident.frozen_until_source = FreezeSource.MAINTENANCE.value
+
+        await manager.reconcile_incident(incident)
+
+        assert incident.frozen_until == second.ends_at
+        manager.queue.put.assert_awaited_once_with(
+            second.ends_at,
+            QueueItemType.UNFREEZE,
+            incident.uniq_id,
+            data=FreezeSource.MAINTENANCE.value,
+        )
 
     @pytest.mark.asyncio
     async def test_reconcile_strips_sentinel_when_window_ended(self, maintenance_setup):

--- a/tests/test_maintenance/test_store.py
+++ b/tests/test_maintenance/test_store.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from unittest.mock import patch
 
@@ -92,6 +92,34 @@ def test_prune_expired_windows(tmp_path: Path):
         assert removed == 1
         assert len(store.load_windows()) == 1
         assert store.load_windows()[0]["id"] == "recent"
+    finally:
+        mock_config.stop()
+
+
+def test_save_retains_recently_ended_windows_until_closed_timeout(tmp_path: Path):
+    store = _make_store(tmp_path)
+    mock_config = _mock_closed_retention("7d")
+    now = datetime.now(timezone.utc)
+    try:
+        recent = {
+            "id": "recent-ended",
+            "start": (now - timedelta(days=1, hours=2)).isoformat(),
+            "end": (now - timedelta(days=1)).isoformat(),
+            "matchers": ['alertname="A"'],
+            "comment": "recent maintenance",
+        }
+        old = {
+            "id": "old-ended",
+            "start": (now - timedelta(days=8, hours=2)).isoformat(),
+            "end": (now - timedelta(days=8)).isoformat(),
+            "matchers": ['alertname="B"'],
+            "comment": "old maintenance",
+        }
+
+        assert store.save_windows([recent, old]) is True
+
+        loaded = store.load_windows()
+        assert [window["id"] for window in loaded] == ["recent-ended"]
     finally:
         mock_config.stop()
 

--- a/tests/test_queue/test_manager.py
+++ b/tests/test_queue/test_manager.py
@@ -61,6 +61,7 @@ class TestAsyncQueueManager:
         manager.would_match_active_window = Mock(return_value=False)
         manager.reconcile_incident = AsyncMock()
         manager.reconcile_all = AsyncMock()
+        manager.handle_window_start = AsyncMock()
         return manager
 
     @pytest.fixture
@@ -197,6 +198,15 @@ class TestAsyncQueueManager:
         queue_manager.unfreeze_handler.handle.assert_awaited_once_with(
             'incident123', FreezeSource.MAINTENANCE.value
         )
+
+    @pytest.mark.asyncio
+    async def test_queue_handle_once_maintenance_start_item(self, queue_manager, mock_queue, mock_maintenance_manager):
+        """Test handling maintenance window start."""
+        mock_queue.get_next_ready_item.return_value = ('maintenance_start', None, 'window-1', None)
+
+        await queue_manager.queue_handle_once()
+
+        mock_maintenance_manager.handle_window_start.assert_awaited_once_with('window-1')
 
     @pytest.mark.asyncio
     async def test_queue_handle_once_unknown_item_type(self, queue_manager, mock_queue):

--- a/tests/test_queue/test_queue.py
+++ b/tests/test_queue/test_queue.py
@@ -145,6 +145,33 @@ class TestAsyncQueue:
         assert len(queue._items) == 1  # Should remain unchanged
 
     @pytest.mark.asyncio
+    async def test_delete_by_type(self, queue):
+        """Test deleting all items of one type."""
+        dt = create_test_datetime()
+        await queue.put(dt, 'maintenance_start', None, 'w1', None)
+        await queue.put(dt, 'maintenance_start', None, 'w2', None)
+        await queue.put(dt, 'update_status', 'incident123', None, None)
+
+        await queue.delete_by_type('maintenance_start')
+
+        assert len(queue._items) == 1
+        assert queue._items[0].type == 'update_status'
+
+    @pytest.mark.asyncio
+    async def test_delete_by_id_type_and_data(self, queue):
+        """Test deleting only queue items matching id, type, and data."""
+        dt = create_test_datetime()
+        await queue.put(dt, 'unfreeze', 'incident123', None, 'maintenance')
+        await queue.put(dt, 'unfreeze', 'incident123', None, 'time')
+        await queue.put(dt, 'unfreeze', 'incident456', None, 'maintenance')
+
+        await queue.delete_by_id_type_and_data('incident123', 'unfreeze', 'maintenance')
+
+        assert len(queue._items) == 2
+        assert {item.data for item in queue._items} == {'time', 'maintenance'}
+        assert any(item.uniq_id == 'incident456' for item in queue._items)
+
+    @pytest.mark.asyncio
     async def test_recreate_resolved_status(self, queue):
         """Test recreate with resolved status (should not add items)."""
         incident_chain = [

--- a/tests/test_queue/test_unfreeze_handler.py
+++ b/tests/test_queue/test_unfreeze_handler.py
@@ -156,3 +156,55 @@ class TestUnfreezeHandler:
         mock_maintenance_manager.reconcile_incident.assert_not_called()
         unfreeze_handler.app.update_incident_message.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_handle_maintenance_source_uses_generic_unfreeze_flow(
+        self, unfreeze_handler, mock_incidents, mock_maintenance_manager
+    ):
+        """Maintenance uses the same queued-unfreeze flow as other sources."""
+        incident = create_mock_incident_for_handlers(
+            frozen_until=datetime.now(timezone.utc),
+            frozen_by_maintenance=True,
+        )
+        incident.uniq_id = "test-uniq-id"
+        incident.frozen_until_source = FreezeSource.MAINTENANCE.value
+        mock_incidents.uniq_ids = {incident.uniq_id: incident}
+
+        with patch("app.queue.handlers.unfreeze_handler.remove_freeze_source", new_callable=AsyncMock) as remove_source:
+            await unfreeze_handler.handle(incident.uniq_id, FreezeSource.MAINTENANCE.value)
+
+        remove_source.assert_awaited_once_with(
+            incident,
+            unfreeze_handler.app,
+            unfreeze_handler.queue,
+            source=FreezeSource.MAINTENANCE,
+            notify=True,
+        )
+        mock_maintenance_manager.reconcile_incident.assert_awaited_once_with(incident, update_message=False)
+        unfreeze_handler.app.update_incident_message.assert_awaited_once_with(incident)
+
+    @pytest.mark.asyncio
+    async def test_handle_maintenance_source_uses_parent_marker_when_time_source_differs(
+        self, unfreeze_handler, mock_incidents, mock_maintenance_manager
+    ):
+        """Maintenance expiry must clear its parent marker without requiring time-source ownership."""
+        incident = create_mock_incident_for_handlers(
+            frozen_until=datetime.now(timezone.utc) + timedelta(hours=1),
+            frozen_by_maintenance=True,
+        )
+        incident.uniq_id = "test-uniq-id"
+        incident.frozen_until_source = FreezeSource.TIME.value
+        mock_incidents.uniq_ids = {incident.uniq_id: incident}
+
+        with patch("app.queue.handlers.unfreeze_handler.remove_freeze_source", new_callable=AsyncMock) as remove_source:
+            await unfreeze_handler.handle(incident.uniq_id, FreezeSource.MAINTENANCE.value)
+
+        remove_source.assert_awaited_once_with(
+            incident,
+            unfreeze_handler.app,
+            unfreeze_handler.queue,
+            source=FreezeSource.MAINTENANCE,
+            notify=True,
+        )
+        mock_maintenance_manager.reconcile_incident.assert_awaited_once_with(incident, update_message=False)
+        unfreeze_handler.app.update_incident_message.assert_awaited_once_with(incident)
+

--- a/tests/test_routes_auth.py
+++ b/tests/test_routes_auth.py
@@ -86,6 +86,7 @@ def _build_app(config, messenger, auth_manager):
     app.state.maintenance_manager = Mock()
     app.state.maintenance_manager.reconcile_after_window_removed = AsyncMock()
     app.state.maintenance_manager.reconcile_all = AsyncMock()
+    app.state.maintenance_manager.schedule_window_starts = AsyncMock()
     app.include_router(create_router("", auth_manager=auth_manager))
     return app
 
@@ -169,6 +170,7 @@ class TestMaintenanceWebsocketAuth:
             mock_store.return_value.save_windows.assert_called_once()
             app.state.maintenance_manager.reconcile_after_window_removed.assert_not_called()
             app.state.maintenance_manager.reconcile_all.assert_awaited_once()
+            app.state.maintenance_manager.schedule_window_starts.assert_awaited_once()
         assert message == {"event": "maintenance_saved", "success": True}
 
     def test_save_maintenance_reconciles_removed_windows(self, config, messenger):


### PR DESCRIPTION
This update introduces the `schedule_window_starts` method in the MaintenanceManager, which queues future maintenance windows for processing. Additionally, the `handle_window_start` method has been added to reconcile incidents when a maintenance window starts. The queue management has been enhanced with new methods for deleting items by type and specific criteria. Tests have been added to ensure the correct functionality of these new features, including the handling of maintenance start events and the scheduling of maintenance windows.