### PR TITLE
Fix route reload

### DIFF
--- a/app/lifespan.py
+++ b/app/lifespan.py
@@ -64,6 +64,7 @@ async def create_main_objects(fastapi_app: FastAPI, reload=False):
 
     if reload:
         fastapi_app.state.inhibition_manager.reload_rules(config_data.app.inhibit_rules)
+        fastapi_app.state.queue_manager.reload_route(route)
     else:
         incidents = Incidents.create_or_load(messenger.type, messenger.public_url, messenger.team)
         JinjaTemplate.set_incidents(incidents)

--- a/app/lifespan.py
+++ b/app/lifespan.py
@@ -63,8 +63,10 @@ async def create_main_objects(fastapi_app: FastAPI, reload=False):
     webhooks = generate_webhooks(webhooks_config)
 
     if reload:
+        user_scheduler = fastapi_app.state.messenger._user_scheduler
         fastapi_app.state.inhibition_manager.reload_rules(config_data.app.inhibit_rules)
-        fastapi_app.state.queue_manager.reload_route(route)
+        messenger.configure_scheduler(user_scheduler)
+        fastapi_app.state.queue_manager.reload_runtime(messenger, webhooks, route)
     else:
         incidents = Incidents.create_or_load(messenger.type, messenger.public_url, messenger.team)
         JinjaTemplate.set_incidents(incidents)

--- a/app/queue/manager.py
+++ b/app/queue/manager.py
@@ -32,6 +32,13 @@ class AsyncQueueManager:
         self._running = False
         self._task = None
 
+    def reload_route(self, route_):
+        self.alert_handler = AlertHandler(
+            self.queue, self.application, self.incidents, route_,
+            self.inhibition_manager, self.maintenance_manager,
+        )
+        logger.info("Alert handler reloaded")
+
     async def handle_alert(self, alert_state: dict):
         await self.alert_handler.handle(alert_state)
 

--- a/app/queue/manager.py
+++ b/app/queue/manager.py
@@ -22,22 +22,35 @@ class AsyncQueueManager:
         self.incidents = incidents
         self.inhibition_manager = inhibition_manager
         self.maintenance_manager = maintenance_manager
-        self.step_handler = StepHandler(self.queue, application, incidents, webhooks)
-        self.status_update_handler = StatusUpdateHandler(self.queue, application, incidents, inhibition_manager)
-        self.status_check_handler = StatusCheckHandler(self.queue, application, incidents, inhibition_manager)
-        self.message_update_handler = MessageUpdateHandler(self.queue, application, incidents)
-        self.alert_handler = AlertHandler(self.queue, application, incidents, route_, inhibition_manager, maintenance_manager)
-        self.unfreeze_handler = UnfreezeHandler(self.queue, application, incidents, maintenance_manager)
-        self.user_update_handler = UserUpdateHandler(self.queue, application, incidents)
+        self._init_handlers(application, webhooks, route_)
         self._running = False
         self._task = None
 
-    def reload_route(self, route_):
+    def _init_handlers(self, application, webhooks, route_):
+        self.step_handler = StepHandler(self.queue, application, self.incidents, webhooks)
+        self.status_update_handler = StatusUpdateHandler(
+            self.queue, application, self.incidents, self.inhibition_manager,
+        )
+        self.status_check_handler = StatusCheckHandler(
+            self.queue, application, self.incidents, self.inhibition_manager,
+        )
+        self.message_update_handler = MessageUpdateHandler(self.queue, application, self.incidents)
         self.alert_handler = AlertHandler(
-            self.queue, self.application, self.incidents, route_,
+            self.queue, application, self.incidents, route_,
             self.inhibition_manager, self.maintenance_manager,
         )
-        logger.info("Alert handler reloaded")
+        self.unfreeze_handler = UnfreezeHandler(
+            self.queue, application, self.incidents, self.maintenance_manager,
+        )
+        self.user_update_handler = UserUpdateHandler(self.queue, application, self.incidents)
+
+    def reload_runtime(self, application, webhooks, route_):
+        logger.info("Reloading queue runtime")
+        self.application = application
+        self.inhibition_manager.application = application
+        self.maintenance_manager.application = application
+        self._init_handlers(application, webhooks, route_)
+        logger.info("Queue runtime reloaded")
 
     async def handle_alert(self, alert_state: dict):
         await self.alert_handler.handle(alert_state)

--- a/tests/test_queue/test_manager.py
+++ b/tests/test_queue/test_manager.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, AsyncMock, patch
 
 import pytest
 
+from app.queue.handlers.alert_handler import AlertHandler
 from app.queue.manager import AsyncQueueManager
 from app.incident.freeze import FreezeSource
 from tests.utils import (
@@ -82,6 +83,21 @@ class TestAsyncQueueManager:
         manager.step_handler.handle = AwaitableMock()
 
         return manager
+
+    def test_reload_route(self, mock_queue, mock_application, mock_incidents, mock_webhooks, mock_route, mock_inhibition_manager, mock_maintenance_manager):
+        """Test reload_route recreates AlertHandler with the new route."""
+        manager = AsyncQueueManager(
+            mock_queue, mock_application, mock_incidents, mock_webhooks,
+            mock_route, mock_inhibition_manager, mock_maintenance_manager,
+        )
+        original_handler = manager.alert_handler
+        new_route = create_mock_route()
+
+        manager.reload_route(new_route)
+
+        assert manager.alert_handler is not original_handler
+        assert isinstance(manager.alert_handler, AlertHandler)
+        assert manager.alert_handler.route is new_route
 
     def test_initialization(self, mock_queue, mock_application, mock_incidents, mock_webhooks, mock_route, mock_inhibition_manager, mock_maintenance_manager):
         """Test AsyncQueueManager initialization."""

--- a/tests/test_queue/test_manager.py
+++ b/tests/test_queue/test_manager.py
@@ -84,20 +84,30 @@ class TestAsyncQueueManager:
 
         return manager
 
-    def test_reload_route(self, mock_queue, mock_application, mock_incidents, mock_webhooks, mock_route, mock_inhibition_manager, mock_maintenance_manager):
-        """Test reload_route recreates AlertHandler with the new route."""
+    def test_reload_runtime(self, mock_queue, mock_application, mock_incidents, mock_webhooks, mock_route, mock_inhibition_manager, mock_maintenance_manager):
+        """Test reload_runtime replaces application, managers, and all handlers."""
         manager = AsyncQueueManager(
             mock_queue, mock_application, mock_incidents, mock_webhooks,
             mock_route, mock_inhibition_manager, mock_maintenance_manager,
         )
-        original_handler = manager.alert_handler
+        original_alert_handler = manager.alert_handler
+        original_step_handler = manager.step_handler
+        new_application = create_mock_application()
+        new_webhooks = create_mock_webhooks_collection()
         new_route = create_mock_route()
 
-        manager.reload_route(new_route)
+        manager.reload_runtime(new_application, new_webhooks, new_route)
 
-        assert manager.alert_handler is not original_handler
+        assert manager.application is new_application
+        assert mock_inhibition_manager.application is new_application
+        assert mock_maintenance_manager.application is new_application
+        assert manager.alert_handler is not original_alert_handler
+        assert manager.step_handler is not original_step_handler
         assert isinstance(manager.alert_handler, AlertHandler)
         assert manager.alert_handler.route is new_route
+        assert manager.alert_handler.app is new_application
+        assert manager.step_handler.webhooks is new_webhooks
+        assert manager.step_handler.app is new_application
 
     def test_initialization(self, mock_queue, mock_application, mock_incidents, mock_webhooks, mock_route, mock_inhibition_manager, mock_maintenance_manager):
         """Test AsyncQueueManager initialization."""


### PR DESCRIPTION
This pull request refactors the queue manager to support runtime reloading of its application and related dependencies, and adds tests to ensure correct behavior. The main changes are the introduction of a `reload_runtime` method to the `AsyncQueueManager`, restructuring handler initialization, and updating the application lifespan to use the new reload logic.

**Queue Manager Runtime Reload Support:**

* Refactored `AsyncQueueManager` to move handler initialization into a new `_init_handlers` method, and added a `reload_runtime` method that updates the application, managers, and all handler instances at runtime.
* Updated the application lifespan logic in `create_main_objects` to call `reload_runtime` on the queue manager when reloading, ensuring all components are refreshed with the latest configuration.

**Testing:**

* Added a test for `reload_runtime` to verify that the application, managers, and all handlers are properly replaced and updated.
* Added missing import for `AlertHandler` in the test file.