### PR TITLE
Enhance Jinja template functionality to support Mattermost markdown link encoding

### DIFF
--- a/app/im/application.py
+++ b/app/im/application.py
@@ -114,10 +114,14 @@ class Application(ABC):
         status_icons = self.status_icons_template.form_message(incident.payload, incident)
         return body, header, status_icons
 
+    def _jinja_template(self, template: str) -> JinjaTemplate:
+        encode_links = self.type == MessengerType.MATTERMOST
+        return JinjaTemplate(template, encode_markdown_link_urls=encode_links)
+
     def generate_template(self):
         def read_template(file_key, default_path):
             file_path = self.templates.get(file_key, default_path)
-            return JinjaTemplate(open(file_path).read())
+            return self._jinja_template(open(file_path).read())
 
         body_template = read_template('body', f'./templates/{self.type.value}_body.j2')
         header_template = read_template('header', f'./templates/{self.type.value}_header.j2')
@@ -205,16 +209,16 @@ class Application(ABC):
         destinations = self.get_notification_destinations()
         if notify_type == 'user':
             unit = self.users.get(identifier)
-            text_template = JinjaTemplate(notification_user)
+            text_template = self._jinja_template(notification_user)
         elif notify_type == 'user_group':
             unit = self.user_groups.get(identifier)
-            text_template = JinjaTemplate(notification_user_group)
+            text_template = self._jinja_template(notification_user_group)
         elif notify_type == 'group':
             unit = self.groups.get(identifier)
-            text_template = JinjaTemplate(notification_group)
+            text_template = self._jinja_template(notification_group)
         else:
             unit = None
-            text_template = JinjaTemplate(notification_user_group)
+            text_template = self._jinja_template(notification_user_group)
         fields = {'type': self.type.value, 'name': identifier, 'unit': unit, 'admins': destinations}
         text = text_template.form_notification(fields)
         _, header, _ = self.form_body_header_status_icons(incident)
@@ -239,7 +243,7 @@ class Application(ABC):
                 'username': incident.assigned_user,
                 'id': incident.assigned_user_id
             }
-            text = JinjaTemplate(notification_assignment).form_notification(fields)
+            text = self._jinja_template(notification_assignment).form_notification(fields)
             if self.type == MessengerType.TELEGRAM:
                 message = text
             else:
@@ -265,7 +269,7 @@ class Application(ABC):
 
         try:
             header = self.header_template.form_message(incident_obj.payload, incident_obj)
-            text = JinjaTemplate(notification_unassignment).form_notification({})
+            text = self._jinja_template(notification_unassignment).form_notification({})
             if self.type.value == MessengerType.TELEGRAM:
                 message = text
             else:
@@ -278,7 +282,7 @@ class Application(ABC):
             logger.error(f'Failed to post unassignment notification for incident {incident_obj.uuid}: {e}')
 
     async def post_unfreeze_notification(self, incident_: 'Incident'):
-        text_template = JinjaTemplate(notification_unfreeze)
+        text_template = self._jinja_template(notification_unfreeze)
         text = text_template.form_notification({'type': self.type.value})
 
         if self.type != MessengerType.TELEGRAM:
@@ -302,7 +306,7 @@ class Application(ABC):
 
             config = get_config()
             if updated_status and incident_status != 'closed' and config.incident.notifications.status_update:
-                text_template = JinjaTemplate(update_status)
+                text_template = self._jinja_template(update_status)
                 admins = self.get_notification_destinations()
                 fields = {'type': self.type.value, 'status': incident_status, 'admins': admins}
                 text = text_template.form_notification(fields)

--- a/app/jinja_template.py
+++ b/app/jinja_template.py
@@ -1,15 +1,29 @@
+import re
 from typing import Optional, TYPE_CHECKING
 from urllib.parse import quote
 
 from jinja2 import Environment
 
+_MARKDOWN_LINK_RE = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
 
-def _urlencode_filter(value):
+
+def _urlencode_url(value: str) -> str:
     return quote(str(value), safe=":/?#[]@!$&'()*+,;=.-_~%")
 
 
+def encode_mattermost_markdown_link_urls(text: str) -> str:
+    """Encode URLs in Markdown [label](url) links for Mattermost mobile rendering."""
+    if not text:
+        return text
+
+    def replace_link(match: re.Match[str]) -> str:
+        label, url = match.group(1), match.group(2)
+        return f'[{label}]({_urlencode_url(url)})'
+
+    return _MARKDOWN_LINK_RE.sub(replace_link, text)
+
+
 _jinja_env = Environment(autoescape=False)  # NOSONAR python:S5439 - not HTML output
-_jinja_env.filters["urlencode"] = _urlencode_filter
 
 if TYPE_CHECKING:
     from app.incident.incident import Incident
@@ -19,24 +33,33 @@ if TYPE_CHECKING:
 class JinjaTemplate:
     _incidents: Optional['Incidents'] = None
 
-    def __init__(self, template: str):
+    def __init__(self, template: str, encode_markdown_link_urls: bool = False):
         self.template = template
+        self._encode_markdown_link_urls = encode_markdown_link_urls
 
     def form_message(self, alert_state, incident: Optional['Incident'] = None):
         """Render a message template with alert state and incident data."""
         template = _jinja_env.from_string(self.template)
         incident_data = incident.serialize() if incident else {}
-        return template.render(payload=alert_state, incident=incident_data, incidents=self._incidents)
+        rendered = template.render(payload=alert_state, incident=incident_data, incidents=self._incidents)
+        return self._finalize(rendered)
 
     def form_notification(self, fields):
         """Render a notification template with provided fields."""
         template = _jinja_env.from_string(self.template)
-        return template.render(fields=fields)
+        rendered = template.render(fields=fields)
+        return self._finalize(rendered)
 
     def render(self, **kwargs):
         """Generic render method for any template with provided kwargs."""
         template = _jinja_env.from_string(self.template)
-        return template.render(**kwargs)
+        rendered = template.render(**kwargs)
+        return self._finalize(rendered)
+
+    def _finalize(self, rendered: str) -> str:
+        if self._encode_markdown_link_urls:
+            return encode_mattermost_markdown_link_urls(rendered)
+        return rendered
 
     @classmethod
     def set_incidents(cls, incidents: Optional['Incidents']):

--- a/app/queue/handlers/alert_handler.py
+++ b/app/queue/handlers/alert_handler.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 from app.config.config import get_config
+from app.config.validation import MessengerType
 from app.im.template import update_alerts
 from app.incident.incident import IncidentConfig, Incident
 from app.jinja_template import JinjaTemplate
@@ -169,7 +170,10 @@ class AlertHandler(BaseHandler):
             'firing': new_alerts_f,
             'resolved': new_alerts_r
         }
-        text = JinjaTemplate(update_alerts).form_notification(fields)
+        text = JinjaTemplate(
+            update_alerts,
+            encode_markdown_link_urls=self.app.type == MessengerType.MATTERMOST,
+        ).form_notification(fields)
         if self.app.type == 'telegram':
             message = text
         else:

--- a/app/queue/handlers/step_handler.py
+++ b/app/queue/handlers/step_handler.py
@@ -36,7 +36,10 @@ class StepHandler(BaseHandler):
             webhook_name = step['identifier']
             webhook = self.webhooks.get(webhook_name)
 
-            text_template = JinjaTemplate(notification_webhook)
+            text_template = JinjaTemplate(
+                notification_webhook,
+                encode_markdown_link_urls=self.app.type == MessengerType.MATTERMOST,
+            )
             admins = self.app.get_notification_destinations()
 
             if webhook is not None:

--- a/templates/mattermost_body.j2
+++ b/templates/mattermost_body.j2
@@ -5,9 +5,9 @@
 {%- if alerts[0].generatorURL %}{% set url = alerts[0].generatorURL %}{% endif -%}
 {%- if commonAnnotations.runbook %}{% set runbook = commonAnnotations.runbook %}{% endif -%}
 {%- if commonAnnotations.summary %}**{{ commonAnnotations.summary }}**  {% endif %}
-{%- if url %}|  [source]({{ url | urlencode }})  {% endif %}
-{%- if runbook %}|  [runbook]({{ runbook | urlencode }})  {% endif %}
-{%- if incident.task_link %}|  [task]({{ incident.task_link | urlencode }})  {% endif %}
+{%- if url %}|  [source]({{ url }})  {% endif %}
+{%- if runbook %}|  [runbook]({{ runbook }})  {% endif %}
+{%- if incident.task_link %}|  [task]({{ incident.task_link }})  {% endif %}
 {%- if incident.assigned_user != "" %} (*assigned to @{{ incident.assigned_user }}*){% endif %}
 {%- if commonAnnotations.description %}
 _{{ commonAnnotations.description }}_{% endif %}
@@ -36,7 +36,7 @@ _{{ commonAnnotations.description }}_{% endif %}
 **Parent incidents:**
 {%- for parent_id in parent_incidents %}
 {%- if parent_id in incidents.uniq_ids %}
-    [{{ incidents.uniq_ids[parent_id].payload.commonLabels.alertname }}]({{ incidents.uniq_ids[parent_id].link | urlencode }})
+    [{{ incidents.uniq_ids[parent_id].payload.commonLabels.alertname }}]({{ incidents.uniq_ids[parent_id].link }})
 {%- else %}
     {{ parent_id }}
 {%- endif %}
@@ -46,6 +46,6 @@ _{{ commonAnnotations.description }}_{% endif %}
 
 **Inhibited incidents:**
 {%- for uniq_id in incident.childs %}
-    [{{ incidents.uniq_ids[uniq_id].payload.commonLabels.alertname }}]({{ incidents.uniq_ids[uniq_id].link | urlencode }})
+    [{{ incidents.uniq_ids[uniq_id].payload.commonLabels.alertname }}]({{ incidents.uniq_ids[uniq_id].link }})
 {%- endfor -%}
 {% endif -%}

--- a/tests/test_jinja_template.py
+++ b/tests/test_jinja_template.py
@@ -1,12 +1,15 @@
 """Tests for Jinja template utilities."""
 from contextlib import contextmanager
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
 
 from app.incident.incident import Incident
-from app.jinja_template import JinjaTemplate
+from app.jinja_template import JinjaTemplate, encode_mattermost_markdown_link_urls
+
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
 
 
 @contextmanager
@@ -42,10 +45,62 @@ def parent_child_incident_context():
 
 class TestJinjaTemplate:
     """Test the JinjaTemplate class."""
-    
+
     def test_render_simple_template(self):
         """Test rendering a simple template."""
         template = JinjaTemplate("Hello {{ name }}!")
         result = template.render(name="World")
         assert result == "Hello World!"
-        
+
+
+class TestEncodeMattermostMarkdownLinkUrls:
+    def test_encodes_quotes_in_markdown_link_url(self):
+        raw = '[task](https://youtrack.example/issue?q="slowpoke")'
+        encoded = encode_mattermost_markdown_link_urls(raw)
+        assert encoded == '[task](https://youtrack.example/issue?q=%22slowpoke%22)'
+
+    def test_preserves_already_percent_encoded_urls(self):
+        raw = '[task](https://example.com/path?q=%22foo%22)'
+        encoded = encode_mattermost_markdown_link_urls(raw)
+        assert encoded == raw
+
+    def test_leaves_plain_text_without_links_unchanged(self):
+        text = 'job "slowpoke" fired on host-1'
+        assert encode_mattermost_markdown_link_urls(text) == text
+
+    def test_mattermost_body_template_encodes_task_link_globally(self):
+        template = JinjaTemplate(
+            (TEMPLATES_DIR / "mattermost_body.j2").read_text(),
+            encode_markdown_link_urls=True,
+        )
+        payload = {
+            "commonAnnotations": {"summary": "summary"},
+            "commonLabels": {},
+            "alerts": [{"labels": {"instance": "host-1"}, "annotations": {}}],
+        }
+        incident = Mock(spec=Incident)
+        incident.serialize = lambda: {
+            "task_link": 'https://youtrack.example/issue?q="slowpoke"',
+            "assigned_user": "",
+            "parents": [],
+            "childs": [],
+        }
+        rendered = template.form_message(payload, incident)
+        assert '[task](https://youtrack.example/issue?q=%22slowpoke%22)' in rendered
+
+    def test_slack_body_template_does_not_encode_links(self):
+        template = JinjaTemplate((TEMPLATES_DIR / "slack_body.j2").read_text())
+        payload = {
+            "commonAnnotations": {"summary": "summary"},
+            "commonLabels": {},
+            "alerts": [{"labels": {"instance": "host-1"}, "annotations": {}}],
+        }
+        incident = Mock(spec=Incident)
+        incident.serialize = lambda: {
+            "task_link": 'https://youtrack.example/issue?q="slowpoke"',
+            "assigned_user_id": "",
+            "parents": [],
+            "childs": [],
+        }
+        rendered = template.form_message(payload, incident)
+        assert '<https://youtrack.example/issue?q="slowpoke"|task>' in rendered


### PR DESCRIPTION
This commit introduces a new method, `encode_mattermost_markdown_link_urls`, which encodes URLs in Markdown links for proper rendering in Mattermost. The `JinjaTemplate` class has been updated to include an option for encoding links, and the template rendering methods have been modified to utilize this functionality. Additionally, tests have been added to ensure the correct encoding behavior for various scenarios, enhancing the overall template rendering capabilities.