### PR TITLE
Add calendar management functions to enhance event handling

### DIFF
--- a/static/js/calendar_shared.js
+++ b/static/js/calendar_shared.js
@@ -5,6 +5,34 @@ export function attachNavListener(btn, handler) {
     }
 }
 
+export function cleanupFullCalendarDragArtifacts() {
+    document.body.classList.remove("fc-not-allowed");
+    for (const mirror of document.querySelectorAll(".fc-event-mirror")) {
+        mirror.remove();
+    }
+}
+
+export function destroyFullCalendarInstance(calendarInstance) {
+    if (calendarInstance) {
+        calendarInstance.destroy();
+    }
+}
+
+const calendarSuspenders = new Map();
+
+export function registerCalendarSuspender(id, suspend) {
+    calendarSuspenders.set(id, suspend);
+}
+
+export function suspendOtherCalendars(activeId) {
+    for (const [id, suspend] of calendarSuspenders) {
+        if (id !== activeId) {
+            suspend();
+        }
+    }
+    cleanupFullCalendarDragArtifacts();
+}
+
 export function getSharedCalendarOptions(firstDay, timezone) {
     return {
         firstDay,

--- a/static/js/chains.js
+++ b/static/js/chains.js
@@ -1,6 +1,14 @@
 import {getSocket} from "./websocket.js";
 import {getBaseUrl, parseWeekStart} from "./utils.js";
-import {attachNavListener, getSharedCalendarOptions, updateMonthCalendarWeekHighlight} from "./calendar_shared.js";
+import {
+    attachNavListener,
+    cleanupFullCalendarDragArtifacts,
+    destroyFullCalendarInstance,
+    getSharedCalendarOptions,
+    registerCalendarSuspender,
+    suspendOtherCalendars,
+    updateMonthCalendarWeekHighlight,
+} from "./calendar_shared.js";
 import {getIsAuthenticated, onAuthChange} from "./auth.js";
 import {
     captureCalendarViewAnchor,
@@ -441,6 +449,19 @@ function getPrivilegedFooterControlsContainer() {
     return document.getElementById("privileged-footer-controls");
 }
 
+function destroyCalendars() {
+    if (eventOverlapObserver) {
+        eventOverlapObserver.disconnect();
+        eventOverlapObserver = null;
+    }
+    destroyFullCalendarInstance(calendar);
+    calendar = null;
+    destroyFullCalendarInstance(monthCalendar);
+    monthCalendar = null;
+    initialized = false;
+    cleanupFullCalendarDragArtifacts();
+}
+
 function closeChainsModal() {
     const chainsModal = document.getElementById("chains-modal");
     chainsModal?.classList.remove("visible");
@@ -471,6 +492,7 @@ function mountFooterToggle() {
 }
 
 function unmountFooterToggle() {
+    destroyCalendars();
     closeChainsModal();
     const toggle = document.getElementById("chains-toggle");
     if (!toggle) {
@@ -487,6 +509,7 @@ async function openChainsModal() {
     if (!getIsAuthenticated()) {
         return;
     }
+    suspendOtherCalendars("chains");
     const chainsModal = document.getElementById("chains-modal");
     if (!chainsModal) {
         return;
@@ -1958,6 +1981,7 @@ export const ChainsManager = {
         if (getIsAuthenticated()) {
             mountFooterToggle();
         }
+        registerCalendarSuspender("chains", destroyCalendars);
         this.initialized = true;
     }
 };

--- a/static/js/maintenance.js
+++ b/static/js/maintenance.js
@@ -1,6 +1,14 @@
 import {getSocket} from "./websocket.js";
 import {getBaseUrl, parseWeekStart} from "./utils.js";
-import {attachNavListener, getSharedCalendarOptions, updateMonthCalendarWeekHighlight} from "./calendar_shared.js";
+import {
+    attachNavListener,
+    cleanupFullCalendarDragArtifacts,
+    destroyFullCalendarInstance,
+    getSharedCalendarOptions,
+    registerCalendarSuspender,
+    suspendOtherCalendars,
+    updateMonthCalendarWeekHighlight,
+} from "./calendar_shared.js";
 import {createEditableFilterBadge} from "./filters.js";
 import {validateAndFormatMatcher, validateMatcher} from "./matcher.js";
 import {getIsAuthenticated, onAuthChange} from "./auth.js";
@@ -237,6 +245,7 @@ function mountFooterToggle() {
 }
 
 function unmountFooterToggle() {
+    destroyCalendars();
     closeMaintenanceModal();
     const toggle = document.getElementById("maintenance-toggle");
     if (!toggle) return;
@@ -864,6 +873,15 @@ async function initializeCalendars() {
     }, 200);
 }
 
+function destroyCalendars() {
+    destroyFullCalendarInstance(calendar);
+    calendar = null;
+    destroyFullCalendarInstance(monthCalendar);
+    monthCalendar = null;
+    initialized = false;
+    cleanupFullCalendarDragArtifacts();
+}
+
 function closeMaintenanceModal() {
     closeWindowModal();
     document.getElementById("maintenance-modal")?.classList.remove("visible");
@@ -871,6 +889,7 @@ function closeMaintenanceModal() {
 
 async function openMaintenanceModal() {
     if (!getIsAuthenticated()) return;
+    suspendOtherCalendars("maintenance");
     const modal = document.getElementById("maintenance-modal");
     if (!modal) return;
 
@@ -960,6 +979,8 @@ export const MaintenanceManager = {
                 closeMaintenanceModal();
             }
         });
+
+        registerCalendarSuspender("maintenance", destroyCalendars);
 
         this.initialized = true;
     },


### PR DESCRIPTION
This commit introduces several new functions in `calendar_shared.js` for managing calendar instances, including `cleanupFullCalendarDragArtifacts`, `destroyFullCalendarInstance`, `registerCalendarSuspender`, and `suspendOtherCalendars`. These functions improve the handling of calendar events by allowing for better cleanup and suspension of inactive calendars. Additionally, the `chains.js` and `maintenance.js` files have been updated to utilize these new functions, ensuring that calendars are properly managed during modal interactions and state changes.