### PR TITLE
Add webhook option to step creation and formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.6.2
+Changes:
+- Added webhook step to UI chains
+
 ## v3.6.1
 Changes:
 - Fix maintenance moving

--- a/static/js/chains.js
+++ b/static/js/chains.js
@@ -604,6 +604,7 @@ function createStepElement(step = null, index = null) {
                 <option value="group">group</option>
                 ${waitOption}
                 <option value="chain">chain</option>
+                <option value="webhook">webhook</option>
             </select>
             <div class="step-value-wrapper">
                 <input type="text" class="step-value" placeholder="Enter value" autocomplete="off">
@@ -658,6 +659,8 @@ function createStepElement(step = null, index = null) {
                 return chainsConfig.groups;
             case 'chain':
                 return chainsConfig.chains;
+            case 'webhook':
+                return chainsConfig.webhooks;
             default:
                 return [];
         }
@@ -803,6 +806,8 @@ function formatStepsText(steps) {
                 return `wait: ${value}`;
             case 'chain':
                 return `chain: ${value}`;
+            case 'webhook':
+                return `webhook: ${value}`;
             default:
                 return `${type}: ${value}`;
         }


### PR DESCRIPTION
- Introduced a new option for 'webhook' in the step selection dropdown within createStepElement.
- Updated the logic to handle 'webhook' cases in step value retrieval and formatting functions, ensuring proper integration with chainsConfig.
- Enhanced the formatStepsText function to include 'webhook' in the formatted output for better clarity in step descriptions.