### PR TITLE
Reconcile orphan inhibition parents on startup and config reload.

### DIFF
--- a/app/inhibition/manager.py
+++ b/app/inhibition/manager.py
@@ -101,7 +101,7 @@ class InhibitionManager:
 
     async def reconcile_orphans(self):
         """Drop stale inhibition parents/childs left after mid-lifecycle restarts."""
-        for incident in list(self.incidents.uniq_ids.values()):
+        for incident in self.incidents.uniq_ids.values():
             orphan_parents = [
                 parent_id for parent_id in incident.parents
                 if parent_id != MAINTENANCE_PARENT_SENTINEL
@@ -123,7 +123,7 @@ class InhibitionManager:
 
             await self._unfreeze_target_if_no_parents(incident)
 
-        for incident in list(self.incidents.uniq_ids.values()):
+        for incident in self.incidents.uniq_ids.values():
             stale_childs = [
                 child_id for child_id in incident.childs
                 if child_id not in self.incidents.uniq_ids

--- a/app/inhibition/manager.py
+++ b/app/inhibition/manager.py
@@ -2,10 +2,12 @@ from typing import Dict, List, Set, TYPE_CHECKING
 
 from app.config.validation import InhibitRule, MessengerType
 from app.inhibition.rule import InhibitionRule
-from app.incident.freeze import FreezeSource
+from app.incident.freeze import FreezeSource, MAINTENANCE_PARENT_SENTINEL
 from app.logging import logger
 
 from app.incident.incident import remove_freeze_source
+
+_INACTIVE_INHIBITION_STATUSES = frozenset({'resolved', 'closed', 'deleted'})
 
 if TYPE_CHECKING:
     from app.incident.incident import Incident
@@ -96,6 +98,45 @@ class InhibitionManager:
         logger.debug("Inhibition state restoration complete",
                    extra={'sources_count': sum(len(s) for s in self.sources.values()),
                          'targets_count': sum(len(t) for t in self.targets.values())})
+
+    async def reconcile_orphans(self):
+        """Drop stale inhibition parents/childs left after mid-lifecycle restarts."""
+        for incident in list(self.incidents.uniq_ids.values()):
+            orphan_parents = [
+                parent_id for parent_id in incident.parents
+                if parent_id != MAINTENANCE_PARENT_SENTINEL
+                and not self._is_active_inhibition_parent(parent_id)
+            ]
+            if not orphan_parents:
+                continue
+
+            for parent_id in orphan_parents:
+                incident.remove_freeze_parent(parent_id)
+                parent = self.incidents.uniq_ids.get(parent_id)
+                if parent and incident.uniq_id in parent.childs:
+                    parent.childs.remove(incident.uniq_id)
+                    parent.dump()
+                logger.info(
+                    "Removed orphan inhibition parent",
+                    extra={'uuid': incident.uuid, 'parent': parent_id},
+                )
+
+            await self._unfreeze_target_if_no_parents(incident)
+
+        for incident in list(self.incidents.uniq_ids.values()):
+            stale_childs = [
+                child_id for child_id in incident.childs
+                if child_id not in self.incidents.uniq_ids
+            ]
+            if not stale_childs:
+                continue
+            for child_id in stale_childs:
+                incident.childs.remove(child_id)
+            incident.dump()
+            logger.info(
+                "Pruned stale inhibition childs",
+                extra={'uuid': incident.uuid, 'childs': stale_childs},
+            )
     
     def would_be_inhibited(self, incident: 'Incident') -> bool:
         if not self.rules:
@@ -208,8 +249,11 @@ class InhibitionManager:
             if done and self.application.type != MessengerType.TELEGRAM:
                 await self.application.update_incident_message(incident)
 
+    def _is_active_inhibition_parent(self, parent_uniq_id: str) -> bool:
+        parent = self.incidents.uniq_ids.get(parent_uniq_id)
+        return parent is not None and parent.status not in _INACTIVE_INHIBITION_STATUSES
+
     async def _unfreeze_target_if_no_parents(self, target: 'Incident'):
-        from app.incident.freeze import MAINTENANCE_PARENT_SENTINEL
         remaining_inhibition_parents = [
             parent for parent in target.parents if parent != MAINTENANCE_PARENT_SENTINEL
         ]

--- a/app/lifespan.py
+++ b/app/lifespan.py
@@ -65,6 +65,7 @@ async def create_main_objects(fastapi_app: FastAPI, reload=False):
     if reload:
         user_scheduler = fastapi_app.state.messenger._user_scheduler
         fastapi_app.state.inhibition_manager.reload_rules(config_data.app.inhibit_rules)
+        await fastapi_app.state.inhibition_manager.reconcile_orphans()
         messenger.configure_scheduler(user_scheduler)
         fastapi_app.state.queue_manager.reload_runtime(messenger, webhooks, route)
     else:
@@ -85,6 +86,7 @@ async def create_main_objects(fastapi_app: FastAPI, reload=False):
             queue=queue,
         )
         inhibition_manager.attach_maintenance_manager(maintenance_manager)
+        await inhibition_manager.reconcile_orphans()
         user_scheduler = UserUpdateScheduler(queue, messenger.type.value)
         messenger.configure_scheduler(user_scheduler)
         await user_scheduler.schedule_all_stored()

--- a/tests/test_inhibition/test_manager.py
+++ b/tests/test_inhibition/test_manager.py
@@ -481,5 +481,116 @@ class TestInhibitionManager:
         assert "old-source" not in inhibition_manager.sources.get(0, set())
         assert "old-target" not in inhibition_manager.targets.get(0, set())
 
+    # Orphan Reconcile Tests
+
+    @pytest.mark.asyncio
+    async def test_reconcile_orphans_removes_missing_parent(
+        self, inhibition_manager, mock_incidents, mock_application
+    ):
+        """Gone source uniq_id is dropped from target parents and inhibition is released."""
+        target = self._create_mock_incident(
+            "target-1", "warning", "api",
+            status="deleted",
+            parents=["missing-source"],
+            frozen_by_inhibition=True,
+        )
+        mock_incidents.uniq_ids = {"target-1": target}
+
+        with patch("app.inhibition.manager.remove_freeze_source", new_callable=AsyncMock) as remove_source:
+            await inhibition_manager.reconcile_orphans()
+
+        assert "missing-source" not in target.parents
+        remove_source.assert_awaited_once_with(
+            target, inhibition_manager.queue, source=FreezeSource.PARENT
+        )
+        mock_application.update_incident_message.assert_awaited_once_with(target)
+
+    @pytest.mark.asyncio
+    async def test_reconcile_orphans_removes_closed_parent_still_on_disk(
+        self, inhibition_manager, mock_incidents
+    ):
+        """Restart-in-air: closed source still loaded must not keep inhibiting children."""
+        source = self._create_mock_incident(
+            "source-1", "critical", "api",
+            status="closed",
+            childs=["target-1"],
+        )
+        target = self._create_mock_incident(
+            "target-1", "warning", "api",
+            status="deleted",
+            parents=["source-1"],
+            frozen_by_inhibition=True,
+        )
+        mock_incidents.uniq_ids = {"source-1": source, "target-1": target}
+
+        with patch("app.inhibition.manager.remove_freeze_source", new_callable=AsyncMock) as remove_source:
+            await inhibition_manager.reconcile_orphans()
+
+        assert "source-1" not in target.parents
+        assert "target-1" not in source.childs
+        source.dump.assert_called()
+        remove_source.assert_awaited_once_with(
+            target, inhibition_manager.queue, source=FreezeSource.PARENT
+        )
+
+    @pytest.mark.asyncio
+    async def test_reconcile_orphans_keeps_active_parent(self, inhibition_manager, mock_incidents):
+        """Firing/unknown parents remain valid inhibition parents."""
+        source = self._create_mock_incident(
+            "source-1", "critical", "api",
+            status="firing",
+            childs=["target-1"],
+        )
+        target = self._create_mock_incident(
+            "target-1", "warning", "api",
+            parents=["source-1"],
+            frozen_by_inhibition=True,
+        )
+        mock_incidents.uniq_ids = {"source-1": source, "target-1": target}
+
+        with patch("app.inhibition.manager.remove_freeze_source", new_callable=AsyncMock) as remove_source:
+            await inhibition_manager.reconcile_orphans()
+
+        assert target.parents == ["source-1"]
+        assert source.childs == ["target-1"]
+        remove_source.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reconcile_orphans_preserves_maintenance_sentinel(
+        self, inhibition_manager, mock_incidents
+    ):
+        """Maintenance parent is kept while gone inhibition parent is dropped."""
+        target = self._create_mock_incident(
+            "target-1", "warning", "api",
+            parents=["missing-source", MAINTENANCE_PARENT_SENTINEL],
+            frozen_by_inhibition=True,
+        )
+        maintenance_manager = Mock()
+        maintenance_manager.reconcile_incident = AsyncMock()
+        inhibition_manager.attach_maintenance_manager(maintenance_manager)
+        mock_incidents.uniq_ids = {"target-1": target}
+
+        with patch("app.inhibition.manager.remove_freeze_source", new_callable=AsyncMock) as remove_source:
+            await inhibition_manager.reconcile_orphans()
+
+        assert target.parents == [MAINTENANCE_PARENT_SENTINEL]
+        remove_source.assert_not_called()
+        maintenance_manager.reconcile_incident.assert_awaited_once_with(target, update_message=False)
+
+    @pytest.mark.asyncio
+    async def test_reconcile_orphans_prunes_stale_childs(self, inhibition_manager, mock_incidents):
+        """Source childs pointing at missing incidents are pruned."""
+        source = self._create_mock_incident(
+            "source-1", "critical", "api",
+            childs=["gone-target", "still-here"],
+        )
+        child = self._create_mock_incident("still-here", "warning", "api", parents=["source-1"])
+        mock_incidents.uniq_ids = {"source-1": source, "still-here": child}
+
+        await inhibition_manager.reconcile_orphans()
+
+        assert source.childs == ["still-here"]
+        source.dump.assert_called()
+
     # Thread Update Tests
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -41,6 +41,7 @@ class TestMainApplication:
             mock_inhibition_manager = Mock()
             mock_inhibition_manager.restore_from_incidents = Mock()
             mock_inhibition_manager.attach_maintenance_manager = Mock()
+            mock_inhibition_manager.reconcile_orphans = AsyncMock()
             mock_inhibition_manager_class.return_value = mock_inhibition_manager
 
             mock_maintenance_store = Mock()


### PR DESCRIPTION
Fixes deleted incidents left frozen after a mid-lifecycle restart when the source was removed without cleanup.