### PR TITLE
Fix Telegram 400 on Grafana URLs by enabling HTML autoescape for Telegram only.

### DIFF
--- a/app/im/application.py
+++ b/app/im/application.py
@@ -117,13 +117,17 @@ class Application(ABC):
     def generate_template(self):
         def read_template(file_key, default_path):
             file_path = self.templates.get(file_key, default_path)
-            return JinjaTemplate(open(file_path).read())
+            return self.jinja_template(open(file_path).read())
 
         body_template = read_template('body', f'./templates/{self.type.value}_body.j2')
         header_template = read_template('header', f'./templates/{self.type.value}_header.j2')
         status_icons_template = read_template('status_icons', f'./templates/{self.type.value}_status_icons.j2')
 
         return body_template, header_template, status_icons_template
+
+    def jinja_template(self, template: str) -> JinjaTemplate:
+        """Build a Jinja template with messenger-appropriate escaping (HTML for Telegram)."""
+        return JinjaTemplate(template, autoescape=self.type == MessengerType.TELEGRAM)
 
     @abstractmethod
     async def get_all_groups(self):
@@ -219,16 +223,16 @@ class Application(ABC):
         destinations = self.get_notification_destinations()
         if notify_type == 'user':
             unit = self.users.get(identifier)
-            text_template = JinjaTemplate(notification_user)
+            text_template = self.jinja_template(notification_user)
         elif notify_type == 'user_group':
             unit = self.user_groups.get(identifier)
-            text_template = JinjaTemplate(notification_user_group)
+            text_template = self.jinja_template(notification_user_group)
         elif notify_type == 'group':
             unit = self.groups.get(identifier)
-            text_template = JinjaTemplate(notification_group)
+            text_template = self.jinja_template(notification_group)
         else:
             unit = None
-            text_template = JinjaTemplate(notification_user_group)
+            text_template = self.jinja_template(notification_user_group)
         fields = {'type': self.type.value, 'name': identifier, 'unit': unit, 'admins': destinations}
         text = text_template.form_notification(fields)
         _, header, _ = self.form_body_header_status_icons(incident)
@@ -253,7 +257,7 @@ class Application(ABC):
                 'username': incident.assigned_user,
                 'id': incident.assigned_user_id
             }
-            text = JinjaTemplate(notification_assignment).form_notification(fields)
+            text = self.jinja_template(notification_assignment).form_notification(fields)
             if self.type == MessengerType.TELEGRAM:
                 message = text
             else:
@@ -279,7 +283,7 @@ class Application(ABC):
 
         try:
             header = self.header_template.form_message(incident_obj.payload, incident_obj)
-            text = JinjaTemplate(notification_unassignment).form_notification({})
+            text = self.jinja_template(notification_unassignment).form_notification({})
             if self.type.value == MessengerType.TELEGRAM:
                 message = text
             else:
@@ -292,8 +296,7 @@ class Application(ABC):
             logger.error(f'Failed to post unassignment notification for incident {incident_obj.uuid}: {e}')
 
     async def post_unfreeze_notification(self, incident_: 'Incident'):
-        text_template = JinjaTemplate(notification_unfreeze)
-        text = text_template.form_notification({'type': self.type.value})
+        text = self.jinja_template(notification_unfreeze).form_notification({'type': self.type.value})
 
         if self.type != MessengerType.TELEGRAM:
             header = self.header_template.form_message(incident_.payload, incident_)
@@ -316,10 +319,9 @@ class Application(ABC):
 
             config = get_config()
             if updated_status and incident_status != 'closed' and config.incident.notifications.status_update:
-                text_template = JinjaTemplate(update_status)
                 admins = self.get_notification_destinations()
                 fields = {'type': self.type.value, 'status': incident_status, 'admins': admins}
-                text = text_template.form_notification(fields)
+                text = self.jinja_template(update_status).form_notification(fields)
 
                 _, header, _ = self.form_body_header_status_icons(incident)
                 message = text if self.type == MessengerType.TELEGRAM else header + '\n' + text

--- a/app/jinja_template.py
+++ b/app/jinja_template.py
@@ -1,32 +1,36 @@
 from typing import Optional, TYPE_CHECKING
 
-from jinja2 import Template
+from jinja2 import Environment
 
 if TYPE_CHECKING:
     from app.incident.incident import Incident
     from app.incident.incidents import Incidents
 
+_plain_env = Environment(autoescape=False)
+_html_env = Environment(autoescape=True)
+
 
 class JinjaTemplate:
     _incidents: Optional['Incidents'] = None
 
-    def __init__(self, template: str):
+    def __init__(self, template: str, autoescape: bool = False):
         self.template = template
+        self._env = _html_env if autoescape else _plain_env
 
     def form_message(self, alert_state, incident: Optional['Incident'] = None):
         """Render a message template with alert state and incident data."""
-        template = Template(self.template)
+        template = self._env.from_string(self.template)
         incident_data = incident.serialize() if incident else {}
         return template.render(payload=alert_state, incident=incident_data, incidents=self._incidents)
 
     def form_notification(self, fields):
         """Render a notification template with provided fields."""
-        template = Template(self.template)
+        template = self._env.from_string(self.template)
         return template.render(fields=fields)
 
     def render(self, **kwargs):
         """Generic render method for any template with provided kwargs."""
-        template = Template(self.template)
+        template = self._env.from_string(self.template)
         return template.render(**kwargs)
 
     @classmethod

--- a/app/queue/handlers/alert_handler.py
+++ b/app/queue/handlers/alert_handler.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 from app.config.config import get_config
 from app.im.template import update_alerts
 from app.incident.incident import IncidentConfig, Incident
-from app.jinja_template import JinjaTemplate
 from app.logging import logger
 from app.queue.constants import QueueItemType
 from app.queue.handlers.base_handler import BaseHandler
@@ -169,7 +168,7 @@ class AlertHandler(BaseHandler):
             'firing': new_alerts_f,
             'resolved': new_alerts_r
         }
-        text = JinjaTemplate(update_alerts).form_notification(fields)
+        text = self.app.jinja_template(update_alerts).form_notification(fields)
         if self.app.type == 'telegram':
             message = text
         else:

--- a/app/queue/handlers/step_handler.py
+++ b/app/queue/handlers/step_handler.py
@@ -1,6 +1,5 @@
 from app.config.validation import MessengerType
 from app.im.template import notification_webhook
-from app.jinja_template import JinjaTemplate
 from app.logging import logger
 from app.queue.handlers.base_handler import BaseHandler
 
@@ -36,7 +35,6 @@ class StepHandler(BaseHandler):
             webhook_name = step['identifier']
             webhook = self.webhooks.get(webhook_name)
 
-            text_template = JinjaTemplate(notification_webhook)
             admins = self.app.get_notification_destinations()
 
             if webhook is not None:
@@ -54,7 +52,7 @@ class StepHandler(BaseHandler):
                 incident.chain_update(identifier, done=True, result=None)
                 logger.warning("Webhook undefined", extra={'uuid': incident.uuid, 'webhook': webhook_name})
 
-            text = text_template.form_notification(fields)
+            text = self.app.jinja_template(notification_webhook).form_notification(fields)
             if self.app.type == MessengerType.TELEGRAM:
                 message = text
             else:

--- a/tests/test_im/test_incident_messages.py
+++ b/tests/test_im/test_incident_messages.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 
 import pytest
 
+from app.config.validation import MessengerType
+from app.im.application import Application
 from app.im.mattermost.threads import _build_mattermost_actions
 from app.im.slack.threads import _build_slack_actions
 from app.jinja_template import JinjaTemplate
@@ -84,7 +86,10 @@ def test_maintenance_freeze_button_label_is_maintenance(builder, config_patch, e
 
 @pytest.mark.parametrize("template_name", ["slack_body.j2", "mattermost_body.j2", "telegram_body.j2"])
 def test_parent_section_hidden_for_maintenance_sentinel_only(template_name):
-    template = JinjaTemplate((TEMPLATES_DIR / template_name).read_text())
+    template = JinjaTemplate(
+        (TEMPLATES_DIR / template_name).read_text(),
+        autoescape=template_name.startswith("telegram_"),
+    )
     incident = SimpleNamespace(serialize=lambda: _incident_data(["maintenance"]))
     JinjaTemplate.set_incidents(SimpleNamespace(uniq_ids={}))
     try:
@@ -99,7 +104,10 @@ def test_parent_section_hidden_for_maintenance_sentinel_only(template_name):
 
 @pytest.mark.parametrize("template_name", ["slack_body.j2", "mattermost_body.j2", "telegram_body.j2"])
 def test_parent_section_shows_only_real_parent_incidents(template_name):
-    template = JinjaTemplate((TEMPLATES_DIR / template_name).read_text())
+    template = JinjaTemplate(
+        (TEMPLATES_DIR / template_name).read_text(),
+        autoescape=template_name.startswith("telegram_"),
+    )
     incident = SimpleNamespace(serialize=lambda: _incident_data(["maintenance", "parent-1"]))
     parent = SimpleNamespace(
         link="https://example.test/parent",
@@ -115,3 +123,51 @@ def test_parent_section_shows_only_real_parent_incidents(template_name):
     assert "Parent sources" not in rendered
     assert "ParentAlert" in rendered
     assert "Maintenance" not in rendered
+
+
+def test_application_jinja_template_autoescape_only_for_telegram():
+    snippet = '<a href="{{ url }}">link</a>'
+    url = 'https://example.com?q="x"&y=1'
+    telegram = Application.jinja_template(SimpleNamespace(type=MessengerType.TELEGRAM), snippet)
+    slack = Application.jinja_template(SimpleNamespace(type=MessengerType.SLACK), snippet)
+
+    assert telegram.render(url=url) == '<a href="https://example.com?q=&#34;x&#34;&amp;y=1">link</a>'
+    assert slack.render(url=url) == '<a href="https://example.com?q="x"&y=1">link</a>'
+
+
+def test_telegram_body_escapes_quotes_in_source_and_runbook_urls():
+    grafana_url = (
+        'https://grafana.iuqweiu.com/explore?orgld=1&left="now-1h","now","VictoriaMetrics",'
+        '{"expr":"rate(kube_pod_container_status_restarts_total{job=\\"kube-state-metrics\\"}[15m])"}'
+    )
+    payload = {
+        "commonAnnotations": {
+            "summary": "Summary",
+            "description": "Test description 'with quotes'",
+            "runbook": grafana_url.replace("grafana.iuqweiu.com", "grafana.tst-st.com"),
+        },
+        "groupLabels": {"alertname": "alert1"},
+        "commonLabels": {
+            "alertname": "alert1",
+            "instance": "localhost:9100",
+            "job": "elasricsearch",
+            "severity": "critical",
+            "service": "elast",
+        },
+        "alerts": [{"generatorURL": grafana_url, "labels": {"instance": "localhost:9100"}, "annotations": {}}],
+    }
+    template = Application.jinja_template(
+        SimpleNamespace(type=MessengerType.TELEGRAM),
+        (TEMPLATES_DIR / "telegram_body.j2").read_text(),
+    )
+    incident = SimpleNamespace(serialize=lambda: _incident_data([]))
+    JinjaTemplate.set_incidents(SimpleNamespace(uniq_ids={}))
+    try:
+        rendered = template.form_message(payload, incident)
+    finally:
+        JinjaTemplate.set_incidents(None)
+
+    assert 'href="https://grafana.iuqweiu.com/explore?orgld=1&amp;left=&#34;now-1h&#34;' in rendered
+    assert 'href="https://grafana.tst-st.com/explore?orgld=1&amp;left=&#34;now-1h&#34;' in rendered
+    assert 'left="now-1h"' not in rendered
+    assert "<i>Test description &#39;with quotes&#39;</i>" in rendered

--- a/tests/test_jinja_template.py
+++ b/tests/test_jinja_template.py
@@ -48,4 +48,19 @@ class TestJinjaTemplate:
         template = JinjaTemplate("Hello {{ name }}!")
         result = template.render(name="World")
         assert result == "Hello World!"
-        
+
+    def test_autoescape_disabled_by_default(self):
+        template = JinjaTemplate('<a href="{{ url }}">link</a>')
+        result = template.render(url='https://example.com?q="x"&y=1')
+        assert result == '<a href="https://example.com?q="x"&y=1">link</a>'
+
+    def test_autoescape_escapes_html_attribute_values(self):
+        template = JinjaTemplate('<a href="{{ url }}">link</a>', autoescape=True)
+        result = template.render(url='https://example.com?q="x"&y=1')
+        assert result == '<a href="https://example.com?q=&#34;x&#34;&amp;y=1">link</a>'
+
+    def test_autoescape_preserves_literal_html_tags(self):
+        template = JinjaTemplate('<b>{{ text }}</b>', autoescape=True)
+        result = template.render(text='Summary <script>')
+        assert result == '<b>Summary &lt;script&gt;</b>'
+


### PR DESCRIPTION
Unescaped quotes and ampersands in generatorURL/runbook broke parse_mode HTML href attributes. Note: HTML in alert annotations/labels is now escaped as text rather than Telegram markup.