### PR TITLE
Deprecate `incidents` special variable in templates; update related d…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes:
 - Added support for `wait` as the first step of any chain
 - **Archive** button state is now stored in the browser
 - Switched logs and incident file names to `uniq_id` instead of `uuid`
+- Deprecated special variable `incidents` in [body templates](https://docs.impulse.bot/stable/concepts/templates/#messages), use `parents` / `childs` instead
 
 ## v3.6.3
 Changes:

--- a/app/jinja_template.py
+++ b/app/jinja_template.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING
 
 from jinja2 import Template
 
+from app.incident.freeze import MAINTENANCE_PARENT_SENTINEL
+
 if TYPE_CHECKING:
     from app.incident.incident import Incident
     from app.incident.incidents import Incidents
@@ -17,8 +19,21 @@ class JinjaTemplate:
     def form_message(self, alert_state, incident: 'Incident | None' = None):
         """Render a message template with alert state and incident data."""
         template = Template(self.template)
-        incident_data = incident.serialize() if incident else {}
-        return template.render(payload=alert_state, incident=incident_data, incidents=self._incidents)
+        if incident:
+            incident_data = incident.serialize()
+            parents = self.related_incidents(incident.parents, skip=(MAINTENANCE_PARENT_SENTINEL,))
+            childs = self.related_incidents(incident.childs)
+        else:
+            incident_data = {}
+            parents = {}
+            childs = {}
+        return template.render(
+            payload=alert_state,
+            incident=incident_data,
+            incidents=self._incidents,
+            parents=parents,
+            childs=childs,
+        )
 
     def form_notification(self, **kwargs):
         """Render a thread notification template with the provided context kwargs."""

--- a/docs/content/concepts/inhibition.md
+++ b/docs/content/concepts/inhibition.md
@@ -4,4 +4,4 @@ Inhibition is similar to [Alertmanager's](https://prometheus.io/docs/alerting/la
 
 [Inhibit rules](../config_file.md#inhibit_rules) allow establishing parent-child relationships between incidents. If two incidents match one of the inhibit rules and the source incident is in the **firing** status, the relationships will be established, and the child will be **frozen** until all its parent incidents are in the **resolved** status.
 
-Incidents have `parents` and `childs` fields which contain lists of corresponding incident `uniq_id` values. This fields can be used in [templates](../config_file.md#messengertemplate_files). See `templates/slack_body.j2` for example.
+Incidents have `parents` and `childs` fields which contain lists of corresponding incident `uniq_id` values. In [templates](templates.md) use the `parents` and `childs` [special variables](special_variables.md) to access related incident objects. See `templates/slack_body.j2` for example.

--- a/docs/content/concepts/templates.md
+++ b/docs/content/concepts/templates.md
@@ -12,6 +12,8 @@ There are 3 templates that users can customize as needed (see [messages structur
 - **header**
 - **body**
 
+**[special variables](special_variables.md):** `incident`, `payload`, `parents`, `childs` (`incidents` is deprecated)
+
 ### Default template
 
 The default **body** template supports 3 links:

--- a/docs/content/config_file.md
+++ b/docs/content/config_file.md
@@ -617,7 +617,7 @@ Below are all the configuration options supported by IMPulse.
 
 - **description:** path to custom template files for `status_icons`, `header`, and `body` (see [Incident Structure](concepts/incident.md#messages-structure))
 - **type:** dict
-- **[special variables](concepts/special_variables.md):** `incident`, `incidents` and `payload` supported
+- **[special variables](concepts/special_variables.md):** `incident`, `payload`, `parents`, `childs` (`incidents` is deprecated)
 - **details:**
     
     !!! note ""

--- a/templates/mattermost_body.j2
+++ b/templates/mattermost_body.j2
@@ -30,22 +30,17 @@ _{{ commonAnnotations.description }}_{% endif %}
     {{ k }}=`{{ v }}`
 {%- endfor -%}
 {% endif -%}
-{%- set parent_incidents = incident.parents | reject("equalto", "maintenance") | list -%}
-{%- if parent_incidents | length > 0 %}
+{%- if parents %}
 
 **Parent incidents:**
-{%- for parent_id in parent_incidents %}
-{%- if parent_id in incidents.uniq_ids %}
-    [{{ incidents.uniq_ids[parent_id].payload.commonLabels.alertname }}]({{ incidents.uniq_ids[parent_id].link | urlencode }})
-{%- else %}
-    {{ parent_id }}
-{%- endif %}
+{%- for parent in parents.values() %}
+    [{{ parent.payload.commonLabels.alertname }}]({{ parent.link | urlencode }})
 {%- endfor -%}
 {% endif -%}
-{%- if incident.childs | length > 0 %}
+{%- if childs %}
 
 **Inhibited incidents:**
-{%- for uniq_id in incident.childs %}
-    [{{ incidents.uniq_ids[uniq_id].payload.commonLabels.alertname }}]({{ incidents.uniq_ids[uniq_id].link }})
+{%- for child in childs.values() %}
+    [{{ child.payload.commonLabels.alertname }}]({{ child.link }})
 {%- endfor -%}
 {% endif -%}

--- a/templates/slack_body.j2
+++ b/templates/slack_body.j2
@@ -30,22 +30,17 @@ _{{ commonAnnotations.description }}_{% endif %}
     {{ k }}=`{{ v }}`
 {%- endfor -%}
 {% endif -%}
-{%- set parent_incidents = incident.parents | reject("equalto", "maintenance") | list -%}
-{%- if parent_incidents | length > 0 %}
+{%- if parents %}
 
 *Parent incidents:*
-{%- for parent_id in parent_incidents %}
-{%- if parent_id in incidents.uniq_ids %}
-    <{{ incidents.uniq_ids[parent_id].link }}|{{ incidents.uniq_ids[parent_id].payload.commonLabels.alertname }}>
-{%- else %}
-    {{ parent_id }}
-{%- endif %}
+{%- for parent in parents.values() %}
+    <{{ parent.link }}|{{ parent.payload.commonLabels.alertname }}>
 {%- endfor -%}
 {% endif -%}
-{%- if incident.childs | length > 0 %}
+{%- if childs %}
 
 *Inhibited incidents:*
-{%- for uniq_id in incident.childs %}
-    <{{ incidents.uniq_ids[uniq_id].link }}|{{ incidents.uniq_ids[uniq_id].payload.commonLabels.alertname }}>
+{%- for child in childs.values() %}
+    <{{ child.link }}|{{ child.payload.commonLabels.alertname }}>
 {%- endfor -%}
 {% endif -%}

--- a/templates/telegram_body.j2
+++ b/templates/telegram_body.j2
@@ -29,22 +29,17 @@
     {{ k }}=<code>{{ v }}</code>
 {%- endfor -%}
 {% endif -%}
-{%- set parent_incidents = incident.parents | reject("equalto", "maintenance") | list -%}
-{%- if parent_incidents | length > 0 %}
+{%- if parents %}
 
 <b>Parent incidents:</b>
-{%- for parent_id in parent_incidents %}
-{%- if parent_id in incidents.uniq_ids %}
-    <a href="{{ incidents.uniq_ids[parent_id].link | e }}">{{ incidents.uniq_ids[parent_id].payload.commonLabels.alertname }}</a>
-{%- else %}
-    {{ parent_id }}
-{%- endif %}
+{%- for parent in parents.values() %}
+    <a href="{{ parent.link | e }}">{{ parent.payload.commonLabels.alertname }}</a>
 {%- endfor -%}
 {% endif -%}
-{%- if incident.childs | length > 0 %}
+{%- if childs %}
 
 <b>Inhibited incidents:</b>
-{%- for uniq_id in incident.childs %}
-    <a href="{{ incidents.uniq_ids[uniq_id].link | e }}">{{ incidents.uniq_ids[uniq_id].payload.commonLabels.alertname }}</a>
+{%- for child in childs.values() %}
+    <a href="{{ child.link | e }}">{{ child.payload.commonLabels.alertname }}</a>
 {%- endfor -%}
 {% endif -%}

--- a/tests/test_im/test_incident_messages.py
+++ b/tests/test_im/test_incident_messages.py
@@ -62,6 +62,13 @@ def _incident_data(parents):
     }
 
 
+def _incident(parents, childs=None):
+    data = _incident_data(parents)
+    if childs is not None:
+        data["childs"] = childs
+    return SimpleNamespace(serialize=lambda: data, parents=parents, childs=data["childs"])
+
+
 @pytest.mark.parametrize(
     ("builder", "config_patch", "env_patch", "label_key"),
     [
@@ -85,7 +92,7 @@ def test_maintenance_freeze_button_label_is_maintenance(builder, config_patch, e
 @pytest.mark.parametrize("template_name", ["slack_body.j2", "mattermost_body.j2", "telegram_body.j2"])
 def test_parent_section_hidden_for_maintenance_sentinel_only(template_name):
     template = JinjaTemplate((TEMPLATES_DIR / template_name).read_text())
-    incident = SimpleNamespace(serialize=lambda: _incident_data(["maintenance"]))
+    incident = _incident(["maintenance"])
     JinjaTemplate.set_incidents(SimpleNamespace(uniq_ids={}))
     try:
         rendered = template.form_message(_payload(), incident)
@@ -100,7 +107,7 @@ def test_parent_section_hidden_for_maintenance_sentinel_only(template_name):
 @pytest.mark.parametrize("template_name", ["slack_body.j2", "mattermost_body.j2", "telegram_body.j2"])
 def test_parent_section_shows_only_real_parent_incidents(template_name):
     template = JinjaTemplate((TEMPLATES_DIR / template_name).read_text())
-    incident = SimpleNamespace(serialize=lambda: _incident_data(["maintenance", "parent-1"]))
+    incident = _incident(["maintenance", "parent-1"])
     parent = SimpleNamespace(
         link="https://example.test/parent",
         payload={"commonLabels": {"alertname": "ParentAlert"}},

--- a/tests/test_jinja_template.py
+++ b/tests/test_jinja_template.py
@@ -1,51 +1,32 @@
 """Tests for Jinja template utilities."""
-from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import Mock
 
-import pytest
-
+from app.incident.freeze import MAINTENANCE_PARENT_SENTINEL
 from app.incident.incident import Incident
 from app.jinja_template import JinjaTemplate
 
 
-@contextmanager
-def parent_child_incident_context():
-    template_str = (
-        "Parent: {{ incident.parents['parent-1'].status }}, "
-        "Child: {{ incident.childs['child-1'].status }}"
-    )
-    template = JinjaTemplate(template_str)
-
-    class MockIncident(Mock):
-        def __init__(self, *args, **kwargs):
-            kwargs.setdefault("spec", Incident)
-            super().__init__(*args, **kwargs)
-
-    incidents = SimpleNamespace(
-        uniq_ids={
-            "parent-1": SimpleNamespace(status="firing"),
-            "child-1": SimpleNamespace(status="resolved"),
-        }
-    )
-
-    JinjaTemplate.set_incidents(incidents)
-    try:
-        mock_incident = MockIncident()
-        mock_incident.parents = ["parent-1"]
-        mock_incident.childs = ["child-1"]
-        mock_incident.serialize.return_value = {"parents": ["parent-1"], "childs": ["child-1"]}
-        yield template, mock_incident
-    finally:
-        JinjaTemplate.set_incidents(None)
-
-
 class TestJinjaTemplate:
-    """Test the JinjaTemplate class."""
-    
     def test_render_simple_template(self):
-        """Test rendering a simple template."""
         template = JinjaTemplate("Hello {{ name }}!")
         result = template.render(name="World")
         assert result == "Hello World!"
-        
+
+    def test_form_message_passes_parents_and_childs(self):
+        template = JinjaTemplate(
+            "Parent: {{ parents['parent-1'].status }}, Child: {{ childs['child-1'].status }}"
+        )
+        parent = SimpleNamespace(status="firing")
+        child = SimpleNamespace(status="resolved")
+        JinjaTemplate.set_incidents(SimpleNamespace(uniq_ids={"parent-1": parent, "child-1": child}))
+        try:
+            incident = Mock(spec=Incident)
+            incident.parents = [MAINTENANCE_PARENT_SENTINEL, "parent-1"]
+            incident.childs = ["child-1"]
+            incident.serialize.return_value = {}
+            result = template.form_message({}, incident)
+        finally:
+            JinjaTemplate.set_incidents(None)
+
+        assert result == "Parent: firing, Child: resolved"


### PR DESCRIPTION
…ocumentation and template files to use `parents` and `childs` instead. Enhance Jinja template rendering to support new variable structure.