### PR TITLE
Actually exit after validating the configuration when running with `--check`

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,6 +40,7 @@ if __name__ == "__main__":
     args = parse_arguments()
     if args.check:
         validate_config_only()
+        raise SystemExit(0)
 
     setup_sighup_forwarder()
 


### PR DESCRIPTION
I was trying to validate my configuration with `--check`, but the server kept running after validation. This doesn't match the documented behavior in https://github.com/eslupmi/impulse/blob/8b22eadeed948275cb65cd18af7b44469c3dfa46/docs/content/concepts/check.md and the cli help for the flag
Exit after validation to match the documented behavior